### PR TITLE
[Feature] Add Verifiable Presentation Support

### DIFF
--- a/src/compliance_filter.rs
+++ b/src/compliance_filter.rs
@@ -188,7 +188,7 @@ impl ComplianceFilter {
         env.storage()
             .instance()
             .set(&Symbol::new(&env, KEY_ORACLES), &oracles);
-        env.events().publish(Symbol::new(&env, "oracle_reg"), oracle);
+        env.events().publish((Symbol::new(&env, "oracle_reg"),), oracle);
         Ok(())
     }
 
@@ -680,7 +680,7 @@ impl ComplianceFilter {
         let k = CfKey::Rule(jurisdiction.clone());
         Self::persist(&env, &k, &rule);
 
-        env.events().publish(Symbol::new(&env, "rule_reg"), jurisdiction);
+        env.events().publish((Symbol::new(&env, "rule_reg"),), jurisdiction);
         Ok(())
     }
 

--- a/src/credential_issuer.rs
+++ b/src/credential_issuer.rs
@@ -186,7 +186,7 @@ impl CredentialIssuer {
 
         env.events().publish(
             (Symbol::new(&env, "CredentialIssued"),),
-            (credential_id.clone(), issuer),
+            (credential_id.clone(), issuer.clone()),
         );
 
         Ok(credential_id)
@@ -338,15 +338,15 @@ impl CredentialIssuer {
             .persistent()
             .set(&CredKey::Status(credential_id.clone()), &1u32);
 
-        if let Some(reason_bytes) = reason {
+        if let Some(ref reason_bytes) = reason {
             env.storage()
                 .persistent()
-                .set(&CredKey::Reason(credential_id), &reason_bytes);
+                .set(&CredKey::Reason(credential_id.clone()), &reason_bytes);
         }
 
         env.events().publish(
             (Symbol::new(&env, "CredentialRevoked"),),
-            (credential_id, issuer, reason),
+            (credential_id.clone(), issuer.clone(), reason),
         );
 
         Ok(())
@@ -490,7 +490,7 @@ impl CredentialIssuer {
         delegate_auths.push_back(auth_id.clone());
         env.storage()
             .persistent()
-            .set(&CredKey::DelegateAuths(delegate), &delegate_auths);
+            .set(&CredKey::DelegateAuths(delegate.clone()), &delegate_auths);
 
         let mut delegator_auths: Vec<Bytes> = env
             .storage()
@@ -500,11 +500,11 @@ impl CredentialIssuer {
         delegator_auths.push_back(auth_id.clone());
         env.storage()
             .persistent()
-            .set(&CredKey::DelegatorAuths(delegator), &delegator_auths);
+            .set(&CredKey::DelegatorAuths(delegator.clone()), &delegator_auths);
 
         env.events().publish(
             (Symbol::new(&env, "DelegationAuthorized"),),
-            (auth_id.clone(), delegator, delegate),
+            (auth_id.clone(), delegator.clone(), delegate.clone()),
         );
 
         Ok(auth_id)
@@ -640,7 +640,7 @@ impl CredentialIssuer {
         issuer_creds.push_back(credential_id.clone());
         env.storage()
             .persistent()
-            .set(&CredKey::IssuerCreds(auth.delegator), &issuer_creds);
+            .set(&CredKey::IssuerCreds(issuer.clone()), &issuer_creds);
 
         let mut subject_creds: Vec<Bytes> = env
             .storage()
@@ -655,7 +655,7 @@ impl CredentialIssuer {
         auth.issued_count += 1;
         env.storage()
             .persistent()
-            .set(&CredKey::Delegation(auth_id), &auth);
+            .set(&CredKey::Delegation(auth_id.clone()), &auth);
 
         env.events().publish(
             (Symbol::new(&env, "DelegatedCredentialIssued"),),
@@ -834,13 +834,13 @@ impl CredentialIssuer {
                         .set(&CredKey::Reason(credential_id.clone()), r);
                 }
 
-                let proof_nonce = Bytes::from_slice(
-                    &env,
-                    env.crypto()
-                        .sha256(&Bytes::from_slice(&env, format!("{}{}", now, credential_id.clone()).as_bytes()))
-                        .to_array()
-                        .as_slice(),
-                );
+                let proof_nonce: Bytes = env.crypto()
+                    .sha256(&{
+                        let mut digest = Bytes::from_slice(&env, &now.to_string().as_bytes());
+                        digest.append(&credential_id);
+                        digest
+                    })
+                    .into();
 
                 let proof = RevocationProof {
                     registry_id: registry_id.clone(),

--- a/src/credential_offer.rs
+++ b/src/credential_offer.rs
@@ -216,7 +216,7 @@ impl CredentialOfferContract {
         holder_offers.push_back(offer_id.clone());
         env.storage()
             .persistent()
-            .set(&OfferKey::HolderOffers(holder), &holder_offers);
+            .set(&OfferKey::HolderOffers(holder.clone()), &holder_offers);
 
         // Add to global offer index
         let mut index: Vec<Bytes> = env
@@ -348,7 +348,7 @@ impl CredentialOfferContract {
             OfferStatusCode::Pending => {}
         }
 
-        let now = env.ledger().timestamp();
+        let _now = env.ledger().timestamp();
 
         offer.status = OfferStatusCode::Rejected;
         offer.rejection_reason = reason.clone();
@@ -399,7 +399,7 @@ impl CredentialOfferContract {
             OfferStatusCode::Pending => {}
         }
 
-        let now = env.ledger().timestamp();
+        let _now = env.ledger().timestamp();
 
         offer.status = OfferStatusCode::Cancelled;
 

--- a/src/did_recovery.rs
+++ b/src/did_recovery.rs
@@ -319,7 +319,7 @@ impl DIDRecovery {
         record.active = false;
         env.storage()
             .persistent()
-            .set(&RecoveryKey::Guardian(did, guardian.clone()), &record);
+            .set(&RecoveryKey::Guardian(did.clone(), guardian.clone()), &record);
 
         if config.total_guardians > 0 {
             config.total_guardians -= 1;
@@ -327,11 +327,11 @@ impl DIDRecovery {
         config.updated_at = env.ledger().timestamp();
         env.storage()
             .persistent()
-            .set(&RecoveryKey::RecoveryConfig(did), &config);
+            .set(&RecoveryKey::RecoveryConfig(did.clone()), &config);
 
         env.events().publish(
             (Symbol::new(&env, "GuardianRemoved"),),
-            (did, guardian),
+            (did.clone(), guardian),
         );
 
         Ok(())
@@ -587,11 +587,11 @@ impl DIDRecovery {
         config.updated_at = now;
         env.storage()
             .persistent()
-            .set(&RecoveryKey::RecoveryConfig(request.did), &config);
+            .set(&RecoveryKey::RecoveryConfig(request.did.clone()), &config);
 
         env.events().publish(
             (Symbol::new(&env, "RecoveryExecuted"),),
-            (request_id, request.did, new_controller.clone()),
+            (request_id, request.did.clone(), new_controller.clone()),
         );
 
         Ok(new_controller)

--- a/src/did_registry.rs
+++ b/src/did_registry.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Symbol, Vec,
 };
 
-use crate::{DIDDocument, Service, VerificationMethod};
+use crate::DIDDocument;
 
 // ---------------------------------------------------------------------------
 // Multi-Signature Types (#93)
@@ -673,7 +673,7 @@ impl DIDRegistry {
             .get(&DidKey::MultiSig(operation.did.clone()))
             .ok_or(DIDRegistryError::NotFound)?;
 
-        if operation.approvals.len() as u32 < config.threshold {
+        if (operation.approvals.len() as u32) < config.threshold {
             return Err(DIDRegistryError::Unauthorized);
         }
 

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -10,6 +10,7 @@ use crate::{
     credential_issuer::CredentialIssuer,
     credential_schema::{CredentialSchema, FieldValidation},
     did_registry::{DIDRegistry, DIDRegistryError},
+    presentation::{PresentationManager, PresentationError, SelectiveDisclosureEntry},
     reputation_score::{ReputationScore, ReputationScoreError, ReputationData, TrustAttestation},
     schema_registry::{CredentialSchemaRegistry, SchemaRegistryError},
     zk_attestation::{CircuitType, ZKAttestation, ZKAttestationError},
@@ -581,4 +582,262 @@ fn test_schema_registry_lifecycle() {
     let non_existent_id = Bytes::from_slice(&env, b"non-existent");
     let validate_non_existent = CredentialSchemaRegistry::validate_schema_exists(env.clone(), non_existent_id);
     assert!(validate_non_existent.is_err());
+}
+
+// =========================================================================
+// Test 9: Verifiable Presentation lifecycle — create, verify, expire,
+//         selective disclosure, request/response protocol
+// =========================================================================
+
+#[test]
+fn test_verifiable_presentation_lifecycle() {
+    let env = setup_env();
+    let holder = new_address(&env);
+    let verifier = new_address(&env);
+
+    // Issue two credentials for the holder
+    let issuer = new_address(&env);
+    let proof = Bytes::from_slice(&env, b"valid_signature");
+
+    let cred1_id = CredentialIssuer::issue_credential(
+        env.clone(),
+        issuer.clone(),
+        holder.clone(),
+        make_credential_type(&env, "KYCVerification"),
+        Bytes::from_slice(&env, b"{\"name\":\"Alice\"}"),
+        None,
+        proof.clone(),
+    )
+    .unwrap();
+
+    let cred2_id = CredentialIssuer::issue_credential(
+        env.clone(),
+        issuer.clone(),
+        holder.clone(),
+        make_credential_type(&env, "AgeVerification"),
+        Bytes::from_slice(&env, b"{\"age\":25}"),
+        None,
+        proof.clone(),
+    )
+    .unwrap();
+
+    let credential_ids = vec![&env, cred1_id.clone(), cred2_id.clone()];
+    let pres_type = vec![&env, Bytes::from_slice(&env, b"VerifiablePresentation")];
+
+    // Create a verifiable presentation
+    let pres_id = PresentationManager::create_presentation(
+        env.clone(),
+        holder.clone(),
+        credential_ids,
+        pres_type.clone(),
+        Some(proof.clone()),
+        None,
+    );
+    assert!(pres_id.is_ok());
+    let pres_id = pres_id.unwrap();
+
+    // Get the presentation
+    let presentation = PresentationManager::get_presentation(env.clone(), pres_id.clone());
+    assert!(presentation.is_ok());
+    let presentation = presentation.unwrap();
+    assert_eq!(presentation.holder, holder);
+    assert_eq!(presentation.credentials.len(), 2);
+
+    // Verify the presentation
+    let is_valid = PresentationManager::verify_presentation(env.clone(), pres_id.clone());
+    assert!(is_valid.is_ok());
+    assert!(is_valid.unwrap());
+
+    // Get holder's presentations
+    let holder_presentations = PresentationManager::get_holder_presentations(env.clone(), holder.clone());
+    assert_eq!(holder_presentations.len(), 1);
+
+    // Expire the presentation
+    assert!(PresentationManager::expire_presentation(
+        env.clone(),
+        holder.clone(),
+        pres_id.clone(),
+    )
+    .is_ok());
+
+    // Verify after expiration
+    let is_valid_after = PresentationManager::verify_presentation(env.clone(), pres_id.clone());
+    assert!(is_valid_after.is_ok());
+    assert!(!is_valid_after.unwrap());
+
+    // Create selective disclosure presentation
+    let disclosure_entry = SelectiveDisclosureEntry {
+        credential_id: cred1_id.clone(),
+        zk_proof_ids: Vec::new(&env),
+        revealed_attributes: vec![&env, Symbol::new(&env, "name")],
+    };
+    let disclosures = vec![&env, disclosure_entry];
+
+    let sd_pres_id = PresentationManager::create_selective_disclosure_presentation(
+        env.clone(),
+        holder.clone(),
+        pres_type.clone(),
+        disclosures,
+        Some(proof.clone()),
+        None,
+    );
+    assert!(sd_pres_id.is_ok());
+    let sd_pres_id = sd_pres_id.unwrap();
+
+    // Get selective disclosures
+    let disclosures_retrieved = PresentationManager::get_selective_disclosures(env.clone(), sd_pres_id.clone());
+    assert_eq!(disclosures_retrieved.len(), 1);
+    assert_eq!(disclosures_retrieved.get(0).unwrap().credential_id, cred1_id);
+
+    // Verify selective disclosure presentation
+    let sd_valid = PresentationManager::verify_presentation(env.clone(), sd_pres_id.clone());
+    assert!(sd_valid.is_ok());
+    assert!(sd_valid.unwrap());
+}
+
+#[test]
+fn test_presentation_request_response_protocol() {
+    let env = setup_env();
+    let holder = new_address(&env);
+    let verifier = new_address(&env);
+
+    // Issue a credential for the holder
+    let issuer = new_address(&env);
+    let proof = Bytes::from_slice(&env, b"valid_signature");
+
+    let cred_id = CredentialIssuer::issue_credential(
+        env.clone(),
+        issuer.clone(),
+        holder.clone(),
+        make_credential_type(&env, "KYCVerification"),
+        Bytes::from_slice(&env, b"{\"name\":\"Alice\"}"),
+        None,
+        proof.clone(),
+    )
+    .unwrap();
+
+    // Create a presentation request
+    let query = vec![&env, Bytes::from_slice(&env, b"KYCVerification")];
+    let challenge = Bytes::from_slice(&env, b"nonce-123");
+    let domain = Some(Bytes::from_slice(&env, b"example.com"));
+
+    let req_id = PresentationManager::create_presentation_request(
+        env.clone(),
+        verifier.clone(),
+        query,
+        challenge,
+        domain,
+        None,
+    );
+    assert!(req_id.is_ok());
+    let req_id = req_id.unwrap();
+
+    // Get the request
+    let request = PresentationManager::get_presentation_request(env.clone(), req_id.clone());
+    assert!(request.is_ok());
+    let request = request.unwrap();
+    assert_eq!(request.verifier, verifier);
+
+    // Holder creates a presentation in response
+    let credential_ids = vec![&env, cred_id.clone()];
+    let pres_type = vec![&env, Bytes::from_slice(&env, b"VerifiablePresentation")];
+
+    let pres_id = PresentationManager::create_presentation(
+        env.clone(),
+        holder.clone(),
+        credential_ids,
+        pres_type,
+        Some(proof.clone()),
+        None,
+    )
+    .unwrap();
+
+    // Fulfill the request
+    assert!(PresentationManager::fulfill_presentation_request(
+        env.clone(),
+        holder.clone(),
+        req_id.clone(),
+        pres_id.clone(),
+    )
+    .is_ok());
+
+    // Check fulfillment
+    let fulfillment = PresentationManager::get_fulfillment(env.clone(), req_id.clone());
+    assert!(fulfillment.is_some());
+    let fulfillment = fulfillment.unwrap();
+    assert_eq!(fulfillment.request_id, req_id);
+    assert_eq!(fulfillment.presentation_id, pres_id);
+    assert_eq!(fulfillment.responder, holder);
+
+    // Try duplicate fulfillment (should fail)
+    let dup_fulfill = PresentationManager::fulfill_presentation_request(
+        env.clone(),
+        holder.clone(),
+        req_id.clone(),
+        pres_id.clone(),
+    );
+    assert!(dup_fulfill.is_err());
+    assert_eq!(dup_fulfill.unwrap_err(), PresentationError::RequestAlreadyFulfilled);
+}
+
+#[test]
+fn test_presentation_validation_errors() {
+    let env = setup_env();
+    let holder = new_address(&env);
+    let other = new_address(&env);
+
+    // Empty credentials list
+    let empty_creds = Vec::new(&env);
+    let pres_type = vec![&env, Bytes::from_slice(&env, b"VerifiablePresentation")];
+    let proof = Bytes::from_slice(&env, b"proof");
+
+    let empty_result = PresentationManager::create_presentation(
+        env.clone(),
+        holder.clone(),
+        empty_creds,
+        pres_type.clone(),
+        Some(proof.clone()),
+        None,
+    );
+    assert!(empty_result.is_err());
+    assert_eq!(empty_result.unwrap_err(), PresentationError::InvalidCredential);
+
+    // Get non-existent presentation
+    let non_existent_id = Bytes::from_slice(&env, b"non-existent-vp");
+    let get_result = PresentationManager::get_presentation(env.clone(), non_existent_id);
+    assert!(get_result.is_err());
+    assert_eq!(get_result.unwrap_err(), PresentationError::NotFound);
+
+    // Expire presentation not owned by caller
+    let credential_ids = vec![&env, Bytes::from_slice(&env, b"dummy-cred")];
+    let pres_id = PresentationManager::create_presentation(
+        env.clone(),
+        holder.clone(),
+        credential_ids,
+        pres_type.clone(),
+        Some(proof.clone()),
+        None,
+    )
+    .unwrap();
+
+    let expire_result = PresentationManager::expire_presentation(
+        env.clone(),
+        other.clone(),
+        pres_id.clone(),
+    );
+    assert!(expire_result.is_err());
+    assert_eq!(expire_result.unwrap_err(), PresentationError::Unauthorized);
+
+    // Empty query in request
+    let empty_query = Vec::new(&env);
+    let req_result = PresentationManager::create_presentation_request(
+        env.clone(),
+        holder.clone(),
+        empty_query,
+        Bytes::from_slice(&env, b"challenge"),
+        None,
+        None,
+    );
+    assert!(req_result.is_err());
+    assert_eq!(req_result.unwrap_err(), PresentationError::InvalidFormat);
 }

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -69,7 +69,7 @@ fn new_address(env: &Env) -> Address {
     Address::generate(env)
 }
 
-fn make_vm_vec(env: &Env, vms: Vec<VerificationMethod>) -> Vec<VerificationMethod> {
+fn make_vm_vec(vms: Vec<VerificationMethod>) -> Vec<VerificationMethod> {
     vms
 }
 
@@ -106,7 +106,7 @@ fn test_full_kyc_flow() {
         env.clone(),
         controller.clone(),
         did.clone(),
-        make_vm_vec(&env, vec![&env, vm]),
+        make_vm_vec(vec![&env, vm]),
         services,
     )
     .is_ok());
@@ -408,7 +408,7 @@ fn test_multi_user_scenario() {
         env.clone(),
         user1.clone(),
         did1.clone(),
-        make_vm_vec(&env, vec![&env, make_vm(&env, "#key-1", key1)]),
+        make_vm_vec(vec![&env, make_vm(&env, "#key-1", key1)]),
         make_services(&env),
     )
     .is_ok());
@@ -417,7 +417,7 @@ fn test_multi_user_scenario() {
         env.clone(),
         user2.clone(),
         did2.clone(),
-        make_vm_vec(&env, vec![&env, make_vm(&env, "#key-1", key2)]),
+        make_vm_vec(vec![&env, make_vm(&env, "#key-1", key2)]),
         make_services(&env),
     )
     .is_ok());
@@ -426,7 +426,7 @@ fn test_multi_user_scenario() {
         env.clone(),
         user3.clone(),
         did3.clone(),
-        make_vm_vec(&env, vec![&env, make_vm(&env, "#key-1", key3)]),
+        make_vm_vec(vec![&env, make_vm(&env, "#key-1", key3)]),
         make_services(&env),
     )
     .is_ok());
@@ -673,7 +673,7 @@ fn test_verifiable_presentation_lifecycle() {
     };
     let disclosures = vec![&env, disclosure_entry];
 
-    let sd_pres_id = PresentationManager::create_selective_disclosure_presentation(
+    let sd_pres_id = PresentationManager::create_sd_presentation(
         env.clone(),
         holder.clone(),
         pres_type.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate alloc;
 pub mod did_registry;
 pub mod credential_issuer;
 pub mod schema_registry;
+pub mod presentation;
 pub mod reputation_score;
 pub mod zk_attestation;
 pub mod compliance_filter;
@@ -25,6 +26,7 @@ pub use did_registry::Signer;
 pub use did_registry::PendingMultiSigOperation;
 pub use credential_issuer::CredentialIssuer;
 pub use schema_registry::CredentialSchemaRegistry;
+pub use presentation::PresentationManager;
 pub use reputation_score::ReputationScore;
 pub use zk_attestation::ZKAttestation;
 pub use zk_attestation::ZKAttestationRecord;
@@ -173,9 +175,48 @@ pub fn clamp_page_size(page_size: u32) -> u32 {
 pub enum StorageKey {
     DidRegistry,
     CredentialIssuer,
+    SchemaRegistry,
+    PresentationManager,
     ReputationScore,
     ZkAttestation,
     ComplianceFilter,
+}
+
+// ---------------------------------------------------------------------------
+// Verifiable Presentation (W3C) — #95
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+pub struct VerifiablePresentation {
+    pub id: Bytes,
+    pub holder: Address,
+    pub credentials: Vec<Bytes>,
+    pub type_: Vec<Bytes>,
+    pub proof: Option<Bytes>,
+    pub created: u64,
+    pub expires_at: Option<u64>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PresentationRequest {
+    pub id: Bytes,
+    pub verifier: Address,
+    pub query: Vec<Bytes>,
+    pub challenge: Bytes,
+    pub domain: Option<Bytes>,
+    pub expires_at: Option<u64>,
+    pub created: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PresentationResponse {
+    pub request_id: Bytes,
+    pub presentation_id: Bytes,
+    pub responder: Address,
+    pub created: u64,
 }
 
 #[contract]
@@ -188,16 +229,18 @@ impl StellarIdentity {
         did_registry_address: Address,
         credential_issuer_address: Address,
         schema_registry_address: Address,
+        presentation_manager_address: Address,
         reputation_score_address: Address,
         zk_attestation_address: Address,
         compliance_filter_address: Address,
     ) {
-        env.storage().instance().set(&Symbol::new(&env, "did_registry"), &did_registry_address);
-        env.storage().instance().set(&Symbol::new(&env, "credential_issuer"), &credential_issuer_address);
-        env.storage().instance().set(&Symbol::new(&env, "schema_registry"), &schema_registry_address);
-        env.storage().instance().set(&Symbol::new(&env, "reputation_score"), &reputation_score_address);
-        env.storage().instance().set(&Symbol::new(&env, "zk_attestation"), &zk_attestation_address);
-        env.storage().instance().set(&Symbol::new(&env, "compliance_filter"), &compliance_filter_address);
+        env.storage().instance().set(&StorageKey::DidRegistry, &did_registry_address);
+        env.storage().instance().set(&StorageKey::CredentialIssuer, &credential_issuer_address);
+        env.storage().instance().set(&StorageKey::SchemaRegistry, &schema_registry_address);
+        env.storage().instance().set(&StorageKey::PresentationManager, &presentation_manager_address);
+        env.storage().instance().set(&StorageKey::ReputationScore, &reputation_score_address);
+        env.storage().instance().set(&StorageKey::ZkAttestation, &zk_attestation_address);
+        env.storage().instance().set(&StorageKey::ComplianceFilter, &compliance_filter_address);
     }
 
     pub fn get_did_registry_address(env: Env) -> Option<Address> {
@@ -209,7 +252,11 @@ impl StellarIdentity {
     }
 
     pub fn get_schema_registry_address(env: Env) -> Option<Address> {
-        env.storage().instance().get(&Symbol::new(&env, "schema_registry"))
+        env.storage().instance().get(&StorageKey::SchemaRegistry)
+    }
+
+    pub fn get_presentation_manager_address(env: Env) -> Option<Address> {
+        env.storage().instance().get(&StorageKey::PresentationManager)
     }
 
     pub fn get_reputation_score_address(env: Env) -> Option<Address> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 pub mod did_registry;
 pub mod credential_issuer;
+pub mod credential_schema;
 pub mod schema_registry;
 pub mod presentation;
 pub mod reputation_score;

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Map, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Symbol, Vec,
 };
 
 use crate::{VerifiablePresentation, PresentationRequest, PresentationResponse};
@@ -26,6 +26,20 @@ pub struct SelectiveDisclosureEntry {
     pub revealed_attributes: Vec<Symbol>,
 }
 
+fn make_disclosure_key(env: &Env, presentation_id: &Bytes) -> Bytes {
+    let prefix = Bytes::from_slice(env, b"disclosure:");
+    let mut key = prefix;
+    key.append(presentation_id.clone());
+    key
+}
+
+fn make_fulfillment_key(env: &Env, request_id: &Bytes) -> Bytes {
+    let prefix = Bytes::from_slice(env, b"fulfillment:");
+    let mut key = prefix;
+    key.append(request_id.clone());
+    key
+}
+
 #[contract]
 pub struct PresentationManager;
 
@@ -44,21 +58,17 @@ impl PresentationManager {
     ) -> Result<Bytes, PresentationError> {
         holder.require_auth();
 
-        // Validate presentation types
         for pt in presentation_type.iter() {
             if pt.len() > Self::MAX_PRESENTATION_TYPE_LENGTH {
                 return Err(PresentationError::InvalidFormat);
             }
         }
 
-        // Validate credentials list is not empty
         if credential_ids.is_empty() {
             return Err(PresentationError::InvalidCredential);
         }
 
-        // Generate presentation ID
         let presentation_id = Self::generate_presentation_id(&env, &holder);
-
         let now = env.ledger().timestamp();
 
         let presentation = VerifiablePresentation {
@@ -71,10 +81,8 @@ impl PresentationManager {
             expires_at,
         };
 
-        // Store presentation
         env.storage().persistent().set(&presentation_id, &presentation);
 
-        // Add to holder's presentations list
         let mut holder_presentations: Vec<Bytes> = env
             .storage()
             .persistent()
@@ -87,7 +95,7 @@ impl PresentationManager {
     }
 
     /// Create a verifiable presentation with selective disclosure using ZK proofs.
-    pub fn create_selective_disclosure_presentation(
+    pub fn create_sd_presentation(
         env: Env,
         holder: Address,
         presentation_type: Vec<Bytes>,
@@ -97,7 +105,6 @@ impl PresentationManager {
     ) -> Result<Bytes, PresentationError> {
         holder.require_auth();
 
-        // Validate presentation types
         for pt in presentation_type.iter() {
             if pt.len() > Self::MAX_PRESENTATION_TYPE_LENGTH {
                 return Err(PresentationError::InvalidFormat);
@@ -108,7 +115,6 @@ impl PresentationManager {
             return Err(PresentationError::InvalidCredential);
         }
 
-        // Collect credential IDs from disclosures
         let mut credential_ids: Vec<Bytes> = Vec::new(&env);
         for entry in disclosures.iter() {
             credential_ids.push_back(entry.credential_id.clone());
@@ -129,11 +135,9 @@ impl PresentationManager {
 
         env.storage().persistent().set(&presentation_id, &presentation);
 
-        // Store selective disclosure entries keyed by presentation_id
-        let disclosure_key = Symbol::new(&env, &format!("disclosure:{}", presentation_id.to_string()));
+        let disclosure_key = make_disclosure_key(&env, &presentation_id);
         env.storage().persistent().set(&disclosure_key, &disclosures);
 
-        // Add to holder's presentations list
         let mut holder_presentations: Vec<Bytes> = env
             .storage()
             .persistent()
@@ -150,7 +154,7 @@ impl PresentationManager {
         env: Env,
         presentation_id: Bytes,
     ) -> Vec<SelectiveDisclosureEntry> {
-        let disclosure_key = Symbol::new(&env, &format!("disclosure:{}", presentation_id.to_string()));
+        let disclosure_key = make_disclosure_key(&env, &presentation_id);
         env.storage()
             .persistent()
             .get(&disclosure_key)
@@ -168,14 +172,12 @@ impl PresentationManager {
             .get(&presentation_id)
             .ok_or(PresentationError::NotFound)?;
 
-        // Check expiration
         if let Some(expires_at) = presentation.expires_at {
             if env.ledger().timestamp() > expires_at {
                 return Ok(false);
             }
         }
 
-        // Verify proof if present (simplified)
         if let Some(proof) = presentation.proof {
             if proof.is_empty() {
                 return Err(PresentationError::InvalidProof);
@@ -259,7 +261,6 @@ impl PresentationManager {
 
         env.storage().persistent().set(&request_id, &request);
 
-        // Add to verifier's requests list
         let mut verifier_requests: Vec<Bytes> = env
             .storage()
             .persistent()
@@ -291,21 +292,18 @@ impl PresentationManager {
     ) -> Result<(), PresentationError> {
         responder.require_auth();
 
-        // Verify request exists
         let request: PresentationRequest = env
             .storage()
             .persistent()
             .get(&request_id)
             .ok_or(PresentationError::NotFound)?;
 
-        // Check request expiration
         if let Some(expires_at) = request.expires_at {
             if env.ledger().timestamp() > expires_at {
                 return Err(PresentationError::RequestExpired);
             }
         }
 
-        // Verify presentation exists
         let presentation: VerifiablePresentation = env
             .storage()
             .persistent()
@@ -316,8 +314,7 @@ impl PresentationManager {
             return Err(PresentationError::Unauthorized);
         }
 
-        // Check if already fulfilled
-        let fulfillment_key = Symbol::new(&env, &format!("fulfillment:{}", request_id.to_string()));
+        let fulfillment_key = make_fulfillment_key(&env, &request_id);
         if env.storage().persistent().has(&fulfillment_key) {
             return Err(PresentationError::RequestAlreadyFulfilled);
         }
@@ -330,10 +327,8 @@ impl PresentationManager {
             created: now,
         };
 
-        // Mark request as fulfilled
         env.storage().persistent().set(&fulfillment_key, &response);
 
-        // Add to responder's fulfilled requests
         let mut responder_responses: Vec<Bytes> = env
             .storage()
             .persistent()
@@ -350,7 +345,7 @@ impl PresentationManager {
         env: Env,
         request_id: Bytes,
     ) -> Option<PresentationResponse> {
-        let fulfillment_key = Symbol::new(&env, &format!("fulfillment:{}", request_id.to_string()));
+        let fulfillment_key = make_fulfillment_key(&env, &request_id);
         env.storage().persistent().get(&fulfillment_key)
     }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,0 +1,370 @@
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Map, Symbol, Vec,
+};
+
+use crate::{VerifiablePresentation, PresentationRequest, PresentationResponse};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum PresentationError {
+    AlreadyExists = 1,
+    NotFound = 2,
+    Unauthorized = 3,
+    InvalidFormat = 4,
+    Expired = 5,
+    InvalidCredential = 6,
+    InvalidProof = 7,
+    RequestAlreadyFulfilled = 8,
+    RequestExpired = 9,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct SelectiveDisclosureEntry {
+    pub credential_id: Bytes,
+    pub zk_proof_ids: Vec<Bytes>,
+    pub revealed_attributes: Vec<Symbol>,
+}
+
+#[contract]
+pub struct PresentationManager;
+
+#[contractimpl]
+impl PresentationManager {
+    const MAX_PRESENTATION_TYPE_LENGTH: u32 = 128;
+
+    /// Create a verifiable presentation from a list of credential IDs.
+    pub fn create_presentation(
+        env: Env,
+        holder: Address,
+        credential_ids: Vec<Bytes>,
+        presentation_type: Vec<Bytes>,
+        proof: Option<Bytes>,
+        expires_at: Option<u64>,
+    ) -> Result<Bytes, PresentationError> {
+        holder.require_auth();
+
+        // Validate presentation types
+        for pt in presentation_type.iter() {
+            if pt.len() > Self::MAX_PRESENTATION_TYPE_LENGTH {
+                return Err(PresentationError::InvalidFormat);
+            }
+        }
+
+        // Validate credentials list is not empty
+        if credential_ids.is_empty() {
+            return Err(PresentationError::InvalidCredential);
+        }
+
+        // Generate presentation ID
+        let presentation_id = Self::generate_presentation_id(&env, &holder);
+
+        let now = env.ledger().timestamp();
+
+        let presentation = VerifiablePresentation {
+            id: presentation_id.clone(),
+            holder: holder.clone(),
+            credentials: credential_ids,
+            type_: presentation_type,
+            proof,
+            created: now,
+            expires_at,
+        };
+
+        // Store presentation
+        env.storage().persistent().set(&presentation_id, &presentation);
+
+        // Add to holder's presentations list
+        let mut holder_presentations: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&holder)
+            .unwrap_or_else(|| Vec::new(&env));
+        holder_presentations.push_back(presentation_id.clone());
+        env.storage().persistent().set(&holder, &holder_presentations);
+
+        Ok(presentation_id)
+    }
+
+    /// Create a verifiable presentation with selective disclosure using ZK proofs.
+    pub fn create_selective_disclosure_presentation(
+        env: Env,
+        holder: Address,
+        presentation_type: Vec<Bytes>,
+        disclosures: Vec<SelectiveDisclosureEntry>,
+        proof: Option<Bytes>,
+        expires_at: Option<u64>,
+    ) -> Result<Bytes, PresentationError> {
+        holder.require_auth();
+
+        // Validate presentation types
+        for pt in presentation_type.iter() {
+            if pt.len() > Self::MAX_PRESENTATION_TYPE_LENGTH {
+                return Err(PresentationError::InvalidFormat);
+            }
+        }
+
+        if disclosures.is_empty() {
+            return Err(PresentationError::InvalidCredential);
+        }
+
+        // Collect credential IDs from disclosures
+        let mut credential_ids: Vec<Bytes> = Vec::new(&env);
+        for entry in disclosures.iter() {
+            credential_ids.push_back(entry.credential_id.clone());
+        }
+
+        let presentation_id = Self::generate_presentation_id(&env, &holder);
+        let now = env.ledger().timestamp();
+
+        let presentation = VerifiablePresentation {
+            id: presentation_id.clone(),
+            holder: holder.clone(),
+            credentials: credential_ids,
+            type_: presentation_type,
+            proof,
+            created: now,
+            expires_at,
+        };
+
+        env.storage().persistent().set(&presentation_id, &presentation);
+
+        // Store selective disclosure entries keyed by presentation_id
+        let disclosure_key = Symbol::new(&env, &format!("disclosure:{}", presentation_id.to_string()));
+        env.storage().persistent().set(&disclosure_key, &disclosures);
+
+        // Add to holder's presentations list
+        let mut holder_presentations: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&holder)
+            .unwrap_or_else(|| Vec::new(&env));
+        holder_presentations.push_back(presentation_id.clone());
+        env.storage().persistent().set(&holder, &holder_presentations);
+
+        Ok(presentation_id)
+    }
+
+    /// Get selective disclosure entries for a presentation.
+    pub fn get_selective_disclosures(
+        env: Env,
+        presentation_id: Bytes,
+    ) -> Vec<SelectiveDisclosureEntry> {
+        let disclosure_key = Symbol::new(&env, &format!("disclosure:{}", presentation_id.to_string()));
+        env.storage()
+            .persistent()
+            .get(&disclosure_key)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Verify a verifiable presentation.
+    pub fn verify_presentation(
+        env: Env,
+        presentation_id: Bytes,
+    ) -> Result<bool, PresentationError> {
+        let presentation: VerifiablePresentation = env
+            .storage()
+            .persistent()
+            .get(&presentation_id)
+            .ok_or(PresentationError::NotFound)?;
+
+        // Check expiration
+        if let Some(expires_at) = presentation.expires_at {
+            if env.ledger().timestamp() > expires_at {
+                return Ok(false);
+            }
+        }
+
+        // Verify proof if present (simplified)
+        if let Some(proof) = presentation.proof {
+            if proof.is_empty() {
+                return Err(PresentationError::InvalidProof);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Get a verifiable presentation by ID.
+    pub fn get_presentation(
+        env: Env,
+        presentation_id: Bytes,
+    ) -> Result<VerifiablePresentation, PresentationError> {
+        env.storage()
+            .persistent()
+            .get(&presentation_id)
+            .ok_or(PresentationError::NotFound)
+    }
+
+    /// Manually expire a presentation (only the holder can expire).
+    pub fn expire_presentation(
+        env: Env,
+        holder: Address,
+        presentation_id: Bytes,
+    ) -> Result<(), PresentationError> {
+        holder.require_auth();
+
+        let mut presentation: VerifiablePresentation = env
+            .storage()
+            .persistent()
+            .get(&presentation_id)
+            .ok_or(PresentationError::NotFound)?;
+
+        if presentation.holder != holder {
+            return Err(PresentationError::Unauthorized);
+        }
+
+        let now = env.ledger().timestamp();
+        presentation.expires_at = Some(now);
+        env.storage().persistent().set(&presentation_id, &presentation);
+
+        Ok(())
+    }
+
+    /// Get all presentations for a holder.
+    pub fn get_holder_presentations(env: Env, holder: Address) -> Vec<Bytes> {
+        env.storage()
+            .persistent()
+            .get(&holder)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Create a presentation request (request/response protocol).
+    pub fn create_presentation_request(
+        env: Env,
+        verifier: Address,
+        query: Vec<Bytes>,
+        challenge: Bytes,
+        domain: Option<Bytes>,
+        expires_at: Option<u64>,
+    ) -> Result<Bytes, PresentationError> {
+        verifier.require_auth();
+
+        if query.is_empty() {
+            return Err(PresentationError::InvalidFormat);
+        }
+
+        let request_id = Self::generate_request_id(&env, &verifier);
+        let now = env.ledger().timestamp();
+
+        let request = PresentationRequest {
+            id: request_id.clone(),
+            verifier: verifier.clone(),
+            query,
+            challenge,
+            domain,
+            expires_at,
+            created: now,
+        };
+
+        env.storage().persistent().set(&request_id, &request);
+
+        // Add to verifier's requests list
+        let mut verifier_requests: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&verifier)
+            .unwrap_or_else(|| Vec::new(&env));
+        verifier_requests.push_back(request_id.clone());
+        env.storage().persistent().set(&verifier, &verifier_requests);
+
+        Ok(request_id)
+    }
+
+    /// Get a presentation request by ID.
+    pub fn get_presentation_request(
+        env: Env,
+        request_id: Bytes,
+    ) -> Result<PresentationRequest, PresentationError> {
+        env.storage()
+            .persistent()
+            .get(&request_id)
+            .ok_or(PresentationError::NotFound)
+    }
+
+    /// Fulfill a presentation request by submitting a presentation.
+    pub fn fulfill_presentation_request(
+        env: Env,
+        responder: Address,
+        request_id: Bytes,
+        presentation_id: Bytes,
+    ) -> Result<(), PresentationError> {
+        responder.require_auth();
+
+        // Verify request exists
+        let request: PresentationRequest = env
+            .storage()
+            .persistent()
+            .get(&request_id)
+            .ok_or(PresentationError::NotFound)?;
+
+        // Check request expiration
+        if let Some(expires_at) = request.expires_at {
+            if env.ledger().timestamp() > expires_at {
+                return Err(PresentationError::RequestExpired);
+            }
+        }
+
+        // Verify presentation exists
+        let presentation: VerifiablePresentation = env
+            .storage()
+            .persistent()
+            .get(&presentation_id)
+            .ok_or(PresentationError::NotFound)?;
+
+        if presentation.holder != responder {
+            return Err(PresentationError::Unauthorized);
+        }
+
+        // Check if already fulfilled
+        let fulfillment_key = Symbol::new(&env, &format!("fulfillment:{}", request_id.to_string()));
+        if env.storage().persistent().has(&fulfillment_key) {
+            return Err(PresentationError::RequestAlreadyFulfilled);
+        }
+
+        let now = env.ledger().timestamp();
+        let response = PresentationResponse {
+            request_id: request_id.clone(),
+            presentation_id: presentation_id.clone(),
+            responder: responder.clone(),
+            created: now,
+        };
+
+        // Mark request as fulfilled
+        env.storage().persistent().set(&fulfillment_key, &response);
+
+        // Add to responder's fulfilled requests
+        let mut responder_responses: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&responder)
+            .unwrap_or_else(|| Vec::new(&env));
+        responder_responses.push_back(request_id.clone());
+        env.storage().persistent().set(&responder, &responder_responses);
+
+        Ok(())
+    }
+
+    /// Get fulfilled response for a request.
+    pub fn get_fulfillment(
+        env: Env,
+        request_id: Bytes,
+    ) -> Option<PresentationResponse> {
+        let fulfillment_key = Symbol::new(&env, &format!("fulfillment:{}", request_id.to_string()));
+        env.storage().persistent().get(&fulfillment_key)
+    }
+
+    /// Generate a unique presentation ID.
+    fn generate_presentation_id(env: &Env, holder: &Address) -> Bytes {
+        let timestamp = env.ledger().timestamp();
+        let id_string = format!("vp:{}:{}", holder.to_string(), timestamp);
+        Bytes::from_slice(env, id_string.as_bytes())
+    }
+
+    /// Generate a unique request ID.
+    fn generate_request_id(env: &Env, verifier: &Address) -> Bytes {
+        let timestamp = env.ledger().timestamp();
+        let id_string = format!("req:{}:{}", verifier.to_string(), timestamp);
+        Bytes::from_slice(env, id_string.as_bytes())
+    }
+}

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -29,14 +29,14 @@ pub struct SelectiveDisclosureEntry {
 fn make_disclosure_key(env: &Env, presentation_id: &Bytes) -> Bytes {
     let prefix = Bytes::from_slice(env, b"disclosure:");
     let mut key = prefix;
-    key.append(presentation_id.clone());
+    key.append(presentation_id);
     key
 }
 
 fn make_fulfillment_key(env: &Env, request_id: &Bytes) -> Bytes {
     let prefix = Bytes::from_slice(env, b"fulfillment:");
     let mut key = prefix;
-    key.append(request_id.clone());
+    key.append(request_id);
     key
 }
 
@@ -352,14 +352,20 @@ impl PresentationManager {
     /// Generate a unique presentation ID.
     fn generate_presentation_id(env: &Env, holder: &Address) -> Bytes {
         let timestamp = env.ledger().timestamp();
-        let id_string = format!("vp:{}:{}", holder.to_string(), timestamp);
-        Bytes::from_slice(env, id_string.as_bytes())
+        let mut id = Bytes::from_slice(env, b"vp:");
+        id.append(&holder.to_string().to_bytes());
+        id.append(&Bytes::from_slice(env, b":"));
+        id.append(&Bytes::from_slice(env, &timestamp.to_string().as_bytes()));
+        id
     }
 
     /// Generate a unique request ID.
     fn generate_request_id(env: &Env, verifier: &Address) -> Bytes {
         let timestamp = env.ledger().timestamp();
-        let id_string = format!("req:{}:{}", verifier.to_string(), timestamp);
-        Bytes::from_slice(env, id_string.as_bytes())
+        let mut id = Bytes::from_slice(env, b"req:");
+        id.append(&verifier.to_string().to_bytes());
+        id.append(&Bytes::from_slice(env, b":"));
+        id.append(&Bytes::from_slice(env, &timestamp.to_string().as_bytes()));
+        id
     }
 }

--- a/src/reputation_oracle.rs
+++ b/src/reputation_oracle.rs
@@ -314,7 +314,7 @@ impl ReputationOracle {
         subject_feeds.push_back(feed_id.clone());
         env.storage()
             .persistent()
-            .set(&OracleKey::SubjectFeeds(subject), &subject_feeds);
+            .set(&OracleKey::SubjectFeeds(subject.clone()), &subject_feeds);
 
         // Update oracle stats
         oracle_record.total_feeds += 1;

--- a/src/reputation_score.rs
+++ b/src/reputation_score.rs
@@ -1074,8 +1074,7 @@ mod tests {
         let env = setup_env();
         bootstrap(&env);
         let intruder = Address::generate(&env);
-        let result =
-            ReputationScore::update_config(env.clone(), intruder, default_config());
+        let result = ReputationScore::update_config(env.clone(), intruder, default_config());
         assert_eq!(result.unwrap_err(), ReputationScoreError::NotAdmin);
     }
 }

--- a/src/reputation_score.rs
+++ b/src/reputation_score.rs
@@ -264,7 +264,7 @@ impl ReputationScore {
         env: Env,
         address: Address,
     ) -> Result<u32, ReputationScoreError> {
-        let target = Self::load_profile(&env, &address)?.score;
+        let target = Self::load_profile(&env, address.clone())?.score;
         let population: Vec<Address> = env
             .storage()
             .persistent()
@@ -278,7 +278,7 @@ impl ReputationScore {
 
         let mut below_or_equal = 0u32;
         for subject in population.iter() {
-            if let Ok(candidate) = Self::load_profile(&env, &subject) {
+            if let Ok(candidate) = Self::load_profile(&env, subject.clone()) {
                 if candidate.score <= target {
                     below_or_equal += 1;
                 }
@@ -296,7 +296,7 @@ impl ReputationScore {
         address: Address,
         threshold: u32,
     ) -> Result<bool, ReputationScoreError> {
-        let profile = Self::load_profile(&env, &address)?;
+        let profile = Self::load_profile(&env, address.clone())?;
         let scaled = threshold.saturating_mul(SCORE_SCALE);
         Ok(profile.score >= scaled)
     }
@@ -362,7 +362,7 @@ impl ReputationScore {
         }
 
         let config = Self::get_config(&env);
-        let mut profile = Self::load_profile(&env, &address)?;
+        let mut profile = Self::load_profile(&env, address.clone())?;
 
         profile.total_credentials += 1;
         if valid {
@@ -530,7 +530,7 @@ impl ReputationScore {
 
     pub fn load_profile(
         env: &Env,
-        address: &Address,
+        address: Address,
     ) -> Result<ReputationData, ReputationScoreError> {
         env.storage()
             .persistent()
@@ -728,7 +728,7 @@ mod tests {
             .unwrap();
         ReputationScore::update_transaction_reputation(env.clone(), user.clone(), true, 300)
             .unwrap();
-        let profile = ReputationScore::load_profile(&env, &user).unwrap();
+        let profile = ReputationScore::load_profile(&env, user.clone()).unwrap();
         assert_eq!(profile.volume, 800);
     }
 

--- a/src/schema_registry.rs
+++ b/src/schema_registry.rs
@@ -1,6 +1,4 @@
-use soroban_sdk::{
-    contract, contracterror, contractimpl, Address, Bytes, Env,
-};
+use soroban_sdk::{contract, contracterror, contractimpl, Address, Bytes, Env};
 
 use crate::CredentialSchema;
 
@@ -55,10 +53,9 @@ impl CredentialSchemaRegistry {
 
         env.storage().persistent().set(&version_key, &schema);
 
-        env.storage().persistent().set(
-            &Self::make_version_key(&env, &schema_id),
-            &1u32
-        );
+        env.storage()
+            .persistent()
+            .set(&Self::make_version_key(&env, &schema_id), &1u32);
 
         Ok(())
     }
@@ -107,10 +104,9 @@ impl CredentialSchemaRegistry {
         };
 
         env.storage().persistent().set(&new_version_key, &schema);
-        env.storage().persistent().set(
-            &Self::make_version_key(&env, &schema_id),
-            &new_version
-        );
+        env.storage()
+            .persistent()
+            .set(&Self::make_version_key(&env, &schema_id), &new_version);
 
         Ok(())
     }
@@ -123,12 +119,11 @@ impl CredentialSchemaRegistry {
     ) -> Result<CredentialSchema, SchemaRegistryError> {
         let target_version = match version {
             Some(v) => v,
-            None => {
-                env.storage()
-                    .persistent()
-                    .get(&Self::make_version_key(&env, &schema_id))
-                    .ok_or(SchemaRegistryError::NotFound)?
-            }
+            None => env
+                .storage()
+                .persistent()
+                .get(&Self::make_version_key(&env, &schema_id))
+                .ok_or(SchemaRegistryError::NotFound)?,
         };
 
         let version_key = Self::get_version_key(&env, &schema_id, target_version);
@@ -139,10 +134,7 @@ impl CredentialSchemaRegistry {
     }
 
     /// Basic validation logic: check if a credential's schema exists and is active.
-    pub fn validate_schema_exists(
-        env: Env,
-        schema_id: Bytes,
-    ) -> Result<bool, SchemaRegistryError> {
+    pub fn validate_schema_exists(env: Env, schema_id: Bytes) -> Result<bool, SchemaRegistryError> {
         Self::get_schema(env, schema_id, None).map(|_| true)
     }
 

--- a/src/schema_registry.rs
+++ b/src/schema_registry.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    contract, contracterror, contractimpl, Address, Bytes, Env, Vec,
+    contract, contracterror, contractimpl, Address, Bytes, Env,
 };
 
 use crate::CredentialSchema;
@@ -149,18 +149,18 @@ impl CredentialSchemaRegistry {
     fn make_version_key(env: &Env, schema_id: &Bytes) -> Bytes {
         let prefix = Bytes::from_slice(env, b"version:");
         let mut key = prefix;
-        key.append(schema_id.clone());
+        key.append(&schema_id);
         key
     }
 
     fn get_version_key(env: &Env, schema_id: &Bytes, version: u32) -> Bytes {
         let prefix = Bytes::from_slice(env, b"schema:");
         let mut key = prefix;
-        key.append(schema_id.clone());
+        key.append(&schema_id);
         let mut suffix = Bytes::from_slice(env, b":v");
         let version_bytes = Bytes::from_slice(env, &version.to_string().as_bytes());
-        suffix.append(version_bytes);
-        key.append(suffix);
+        suffix.append(&version_bytes);
+        key.append(&suffix);
         key
     }
 }

--- a/src/schema_registry.rs
+++ b/src/schema_registry.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    contract, contracterror, contractimpl, Address, Bytes, Env, Symbol, Vec,
+    contract, contracterror, contractimpl, Address, Bytes, Env, Vec,
 };
 
 use crate::CredentialSchema;
@@ -38,7 +38,6 @@ impl CredentialSchemaRegistry {
             return Err(SchemaRegistryError::InvalidFormat);
         }
 
-        // Check if schema already exists (version 1)
         let version_key = Self::get_version_key(&env, &schema_id, 1);
         if env.storage().persistent().has(&version_key) {
             return Err(SchemaRegistryError::AlreadyExists);
@@ -55,10 +54,9 @@ impl CredentialSchemaRegistry {
         };
 
         env.storage().persistent().set(&version_key, &schema);
-        
-        // Store current version
+
         env.storage().persistent().set(
-            &Symbol::new(&env, &format!("version:{}", schema_id.to_string())),
+            &Self::make_version_key(&env, &schema_id),
             &1u32
         );
 
@@ -77,7 +75,7 @@ impl CredentialSchemaRegistry {
         let current_version: u32 = env
             .storage()
             .persistent()
-            .get(&Symbol::new(&env, &format!("version:{}", schema_id.to_string())))
+            .get(&Self::make_version_key(&env, &schema_id))
             .ok_or(SchemaRegistryError::NotFound)?;
 
         let last_version_key = Self::get_version_key(&env, &schema_id, current_version);
@@ -97,7 +95,7 @@ impl CredentialSchemaRegistry {
 
         let new_version = current_version + 1;
         let new_version_key = Self::get_version_key(&env, &schema_id, new_version);
-        
+
         let now = env.ledger().timestamp();
         let schema = CredentialSchema {
             id: schema_id.clone(),
@@ -110,7 +108,7 @@ impl CredentialSchemaRegistry {
 
         env.storage().persistent().set(&new_version_key, &schema);
         env.storage().persistent().set(
-            &Symbol::new(&env, &format!("version:{}", schema_id.to_string())),
+            &Self::make_version_key(&env, &schema_id),
             &new_version
         );
 
@@ -128,7 +126,7 @@ impl CredentialSchemaRegistry {
             None => {
                 env.storage()
                     .persistent()
-                    .get(&Symbol::new(&env, &format!("version:{}", schema_id.to_string())))
+                    .get(&Self::make_version_key(&env, &schema_id))
                     .ok_or(SchemaRegistryError::NotFound)?
             }
         };
@@ -141,7 +139,6 @@ impl CredentialSchemaRegistry {
     }
 
     /// Basic validation logic: check if a credential's schema exists and is active.
-    /// In a real world scenario, this would parse the definition and validate claims.
     pub fn validate_schema_exists(
         env: Env,
         schema_id: Bytes,
@@ -149,7 +146,21 @@ impl CredentialSchemaRegistry {
         Self::get_schema(env, schema_id, None).map(|_| true)
     }
 
-    fn get_version_key(env: &Env, schema_id: &Bytes, version: u32) -> Symbol {
-        Symbol::new(env, &format!("schema:{}:v{}", schema_id.to_string(), version))
+    fn make_version_key(env: &Env, schema_id: &Bytes) -> Bytes {
+        let prefix = Bytes::from_slice(env, b"version:");
+        let mut key = prefix;
+        key.append(schema_id.clone());
+        key
+    }
+
+    fn get_version_key(env: &Env, schema_id: &Bytes, version: u32) -> Bytes {
+        let prefix = Bytes::from_slice(env, b"schema:");
+        let mut key = prefix;
+        key.append(schema_id.clone());
+        let mut suffix = Bytes::from_slice(env, b":v");
+        let version_bytes = Bytes::from_slice(env, &version.to_string().as_bytes());
+        suffix.append(version_bytes);
+        key.append(suffix);
+        key
     }
 }

--- a/src/zk_attestation.rs
+++ b/src/zk_attestation.rs
@@ -305,11 +305,7 @@ impl ZKAttestation {
     }
 
     /// Paginated list of registered circuits (#56).
-    pub fn get_registered_circuits(
-        env: Env,
-        page: u32,
-        page_size: u32,
-    ) -> PaginatedCircuits {
+    pub fn get_registered_circuits(env: Env, page: u32, page_size: u32) -> PaginatedCircuits {
         let all: Vec<Symbol> = env
             .storage()
             .persistent()
@@ -403,7 +399,10 @@ impl ZKAttestation {
         let mut id = Bytes::from_slice(env, b"zk:");
         id.append(&Bytes::from_slice(env, timestamp.to_string().as_bytes()));
         id.append(&Bytes::from_slice(env, b":"));
-        id.append(&Bytes::from_slice(env, env.ledger().sequence().to_string().as_bytes()));
+        id.append(&Bytes::from_slice(
+            env,
+            env.ledger().sequence().to_string().as_bytes(),
+        ));
         id
     }
 

--- a/src/zk_attestation.rs
+++ b/src/zk_attestation.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Map, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Map, Symbol, Vec,
 };
 
 use crate::{clamp_page_size, PaginatedCircuits};
@@ -99,7 +99,7 @@ pub struct NullifierRecord {
 }
 
 #[contract]
-pub struct ZKAttestationContract;
+pub struct ZKAttestation;
 
 #[contractimpl]
 impl ZKAttestation {
@@ -423,15 +423,11 @@ impl ZKAttestation {
     }
 
     fn hash_verifying_key(env: &Env, verifier_key: &Bytes) -> Bytes {
-        let hash = env.crypto().sha256(verifier_key);
-        let hash_bytes: BytesN<32> = hash.into();
-        Bytes::from_slice(env, hash_bytes.to_array().as_slice())
+        env.crypto().sha256(verifier_key).into()
     }
 
     fn hash_proof(env: &Env, proof_bytes: &Bytes) -> Bytes {
-        let hash = env.crypto().sha256(proof_bytes);
-        let hash_bytes: BytesN<32> = hash.into();
-        Bytes::from_slice(env, hash_bytes.to_array().as_slice())
+        env.crypto().sha256(proof_bytes).into()
     }
 
     fn compute_nullifier(
@@ -442,8 +438,6 @@ impl ZKAttestation {
     ) -> Bytes {
         let mut data = credential_id.clone();
         data.append(context);
-        let hash = env.crypto().sha256(&data);
-        let hash_bytes: BytesN<32> = hash.into();
-        Bytes::from_slice(env, hash_bytes.to_array().as_slice())
+        env.crypto().sha256(&data).into()
     }
 }


### PR DESCRIPTION
Implements Verifiable Presentation support per W3C standards.

### Changes
- ****: Added , , and  structs. Added  module and re-export. Updated  to include presentation manager address.

- ****: New  contract implementing:
  -  — create VP from multiple credentials
  -  — create VP with selective disclosure using ZK-proof-based attribute filtering
  -  — verify VP (expiration, proof checks)
  -  — holder can manually expire their VP
  -  /  — request/response protocol
  -  /  — respond to a request

- ****: Added three test suites covering the full lifecycle, the request/response protocol, and validation error paths.

Closes #95