### PR TITLE
docs(#53): Add JSDoc comments, Typedoc config, and Jest test infrastructure

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/sdk/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: 'tsconfig.json',
+    }],
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/sdk/src/$1',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^8.0.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
+        "typedoc": "^0.28.19",
         "typescript": "^5.0.0"
       }
     },
@@ -554,6 +555,20 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1098,6 +1113,55 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "dev": true,
@@ -1183,6 +1247,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "dev": true,
@@ -1233,6 +1307,13 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2348,6 +2429,19 @@
       "version": "8.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -4041,6 +4135,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -4079,6 +4193,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "dev": true,
@@ -4106,12 +4227,47 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4544,6 +4700,16 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5233,6 +5399,69 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5246,6 +5475,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -5471,6 +5707,22 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "test": "jest",
     "lint": "eslint src/**/*.ts",
     "prepare": "npm run build",
-    "example:cli-demo": "ts-node --script-mode examples/cli-demo.ts"
+    "example:cli-demo": "ts-node --script-mode examples/cli-demo.ts",
+    "docs": "typedoc",
+    "docs:watch": "typedoc --watch",
+    "docs:serve": "npx serve docs/api",
+    "docs:contracts": "cargo doc --no-deps --document-private-items"
   },
   "keywords": [
     "stellar",
@@ -23,27 +27,28 @@
   "author": "Stellar Identity Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "stellar-sdk": "^12.0.0",
-    "did-resolver": "^4.1.0",
-    "web-did-resolver": "^2.0.27",
+    "axios": "^1.6.0",
+    "bs58": "^5.0.0",
+    "crypto-js": "^4.2.0",
     "did-jwt": "^7.2.3",
     "did-jwt-vc": "^3.2.5",
-    "axios": "^1.6.0",
-    "crypto-js": "^4.2.0",
-    "tweetnacl": "^1.0.3",
-    "bs58": "^5.0.0",
+    "did-resolver": "^4.1.0",
     "multiformats": "^12.1.0",
+    "snarkjs": "^0.7.0",
+    "stellar-sdk": "^12.0.0",
+    "tweetnacl": "^1.0.3",
     "uint8arrays": "^4.0.6",
-    "snarkjs": "^0.7.0"
+    "web-did-resolver": "^2.0.27"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
     "@types/jest": "^29.5.0",
+    "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
+    "typedoc": "^0.28.19",
     "typescript": "^5.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
     "docs:serve": "npx serve docs/api",
-    "docs:contracts": "cargo doc --no-deps --document-private-items"
+    "docs:contracts": "cargo doc --no-deps --document-private-items",
+    "docs:all": "npm run docs && cargo doc --no-deps --document-private-items"
   },
   "keywords": [
     "stellar",

--- a/sdk/src/credentialClient.ts
+++ b/sdk/src/credentialClient.ts
@@ -21,6 +21,12 @@ import { DIDClient } from './didClient';
 import { Logger } from './logger';
 import { DataMinimizationEngine, MinimalDisclosurePolicy } from './dataMinimization';
 
+/**
+ * Client for issuing, verifying, and managing verifiable credentials on Stellar.
+ * Supports W3C VC 2.0 format, KYC credentials, education credentials,
+ * presentations, and data minimization policies.
+ * @category Client
+ */
 export class CredentialClient {
   private rpc: SorobanRpc.Server;
   private config: StellarIdentityConfig;
@@ -45,6 +51,13 @@ export class CredentialClient {
     }
   }
 
+  /**
+   * Issue a new verifiable credential to a subject.
+   * @param issuerKeypair - The keypair of the credential issuer
+   * @param options - Credential details including subject, type, and data
+   * @param txOptions - Optional transaction parameters
+   * @returns The credential ID
+   */
   async issueCredential(
     issuerKeypair: Keypair,
     options: IssueCredentialOptions,
@@ -92,6 +105,11 @@ export class CredentialClient {
     }
   }
 
+  /**
+   * Verify the validity of a credential.
+   * @param credentialId - The credential identifier
+   * @returns Verification result with validity, revocation, and expiration status
+   */
   async verifyCredential(credentialId: string): Promise<CredentialVerificationResult> {
     this.logger.debug('verifyCredential called', { credentialId });
     try {
@@ -212,6 +230,16 @@ export class CredentialClient {
     }
   }
 
+  /**
+   * Create a verifiable presentation from one or more credentials.
+   * Optionally applies data minimization policies for selective disclosure.
+   * @param credentials - The credentials to include in the presentation
+   * @param holderKeypair - The holder's keypair for signing
+   * @param domain - Optional domain for the proof
+   * @param challenge - Optional challenge for the proof
+   * @param policy - Optional minimal disclosure policy
+   * @returns A verifiable presentation object
+   */
   async createPresentation(
     credentials: VerifiableCredential[],
     holderKeypair: Keypair,

--- a/sdk/src/didClient.ts
+++ b/sdk/src/didClient.ts
@@ -26,6 +26,12 @@ import {
   mapContractError,
 } from './errors';
 
+/**
+ * Client for managing decentralized identifiers (DIDs) on Stellar.
+ * Provides methods for creating, resolving, updating, and deactivating DIDs
+ * using the W3C did:stellar method via Soroban smart contracts.
+ * @category Client
+ */
 export class DIDClient {
   private rpc: SorobanRpc.Server;
   private config: StellarIdentityConfig;
@@ -43,6 +49,13 @@ export class DIDClient {
     }
   }
 
+  /**
+   * Create a new DID on the Stellar network.
+   * @param keypair - The keypair of the DID controller
+   * @param options - DID creation options including verification methods and services
+   * @param txOptions - Optional transaction parameters (fee, timeout)
+   * @returns The generated DID string (e.g., did:stellar:G...)
+   */
   async createDID(
     keypair: Keypair,
     options: CreateDIDOptions,
@@ -104,6 +117,11 @@ export class DIDClient {
     }
   }
 
+  /**
+   * Resolve a DID to its DID document via on-chain contract call.
+   * @param did - The DID to resolve (e.g., did:stellar:G...)
+   * @returns Resolution result containing the DID document and metadata
+   */
   async resolveDID(did: string): Promise<DIDResolutionResult> {
     try {
       const retval = await this.simulateRead('resolve_did', [
@@ -175,6 +193,11 @@ export class DIDClient {
     }
   }
 
+  /**
+   * Deactivate a DID, preventing further use.
+   * @param keypair - The keypair of the DID controller
+   * @param txOptions - Optional transaction parameters
+   */
   async deactivateDID(keypair: Keypair, txOptions?: TransactionOptions): Promise<void> {
     try {
       const address = keypair.publicKey();

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,3 +1,9 @@
+/**
+ * Error codes for the Stellar Identity SDK.
+ * Organized by domain: DID (1xxx), Credential (2xxx), Reputation (3xxx),
+ * ZK Proof (4xxx), Compliance (5xxx), Config (6xxx), Network (7xxx).
+ * @category Errors
+ */
 export enum ErrorCode {
   // DID errors (maps to DIDRegistryError)
   DIDAlreadyExists = 1001,
@@ -107,6 +113,11 @@ const ERROR_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.NetworkSimulationError]: 'Contract simulation error',
 };
 
+/**
+ * Base error class for all Stellar Identity SDK errors.
+ * Contains an error code and optional details for debugging.
+ * @category Errors
+ */
 export class StellarIdentityError extends Error {
   public readonly code: ErrorCode;
   public readonly details: Record<string, unknown>;
@@ -231,6 +242,14 @@ const ERROR_CODE_MAP: Record<string, [ErrorCode, ErrorClass]> = {
 const RUST_REVERT_PATTERN = /Error\(Contract\(#(\d+)\),?.*?\)/;
 const RUST_ERROR_NAME_PATTERN = /(?<name>[A-Za-z]+Error):(?<variant>[A-Za-z]+)/;
 
+/**
+ * Maps a contract error (from Soroban transaction results) to the appropriate
+ * StellarIdentityError subclass. Handles Rust revert patterns, error name
+ * matching, and fallback to network errors.
+ * @param error - The error to map
+ * @returns A typed StellarIdentityError
+ * @category Errors
+ */
 export function mapContractError(error: unknown): StellarIdentityError {
   if (error instanceof StellarIdentityError) {
     return error;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -115,6 +115,21 @@ import { CacheManager } from './cacheManager';
 import { EventSubscriber } from './eventSubscriber';
 import { StellarIdentityConfig } from './types';
 
+/**
+ * Stellar Identity SDK - Main entry point.
+ *
+ * Composes all client modules (DID, Credentials, Reputation, ZK Proofs,
+ * Compliance) into a single unified SDK with caching and event subscription.
+ *
+ * @example
+ * ```typescript
+ * import { StellarIdentitySDK, DEFAULT_CONFIGS } from '@stellar-identity/sdk';
+ *
+ * const sdk = new StellarIdentitySDK(DEFAULT_CONFIGS.testnet);
+ * const did = await sdk.did.createDID(keypair, options);
+ * ```
+ * @category Client
+ */
 export class StellarIdentitySDK {
   public did: DIDClient;
   public credentials: CredentialClient;
@@ -132,6 +147,13 @@ export class StellarIdentitySDK {
     this.events = new EventSubscriber(config);
   }
 
+  /**
+   * Initialize a complete user identity: create DID and initialize reputation.
+   * @param keypair - The user's Stellar keypair
+   * @param verificationMethods - Array of verification methods for the DID
+   * @param services - Array of service endpoints for the DID
+   * @returns Object containing the DID and Stellar address
+   */
   async initializeUserIdentity(
     keypair: Keypair,
     verificationMethods: any[],
@@ -151,6 +173,12 @@ export class StellarIdentitySDK {
     };
   }
 
+  /**
+   * Get a complete identity profile for an address.
+   * Fetches DID document, reputation data, and credentials in parallel.
+   * @param address - The Stellar address to query
+   * @returns Identity profile with DID, reputation, and credentials
+   */
   async getIdentityProfile(address: string) {
     const [didDocument, reputationData, credentials] = await Promise.all([
       this.did.resolveDID(this.did.generateDID(address)).catch(() => null),

--- a/sdk/src/reputation.ts
+++ b/sdk/src/reputation.ts
@@ -24,6 +24,13 @@ import {
 } from './types';
 import { StellarIdentityError, mapContractError } from './errors';
 
+/**
+ * Client for managing on-chain reputation scores on Stellar.
+ * Calculates reputation from transaction history, credential validity,
+ * trust attestations, and network activity. Supports tier-based scoring
+ * from Seedling through Prime.
+ * @category Client
+ */
 export class ReputationClient {
   private rpc: SorobanRpc.Server;
   private config: StellarIdentityConfig;
@@ -98,6 +105,11 @@ export class ReputationClient {
     return this.normalizeScore(scValToNative(retval));
   }
 
+  /**
+   * Get a comprehensive reputation score breakdown including factors and percentile.
+   * @param did - The DID or Stellar address to query
+   * @returns Reputation breakdown with score, tier, and factor details
+   */
   async getReputationScore(did: string): Promise<ReputationBreakdown> {
     const [data, percentile] = await Promise.all([
       this.getReputationData(did),
@@ -214,6 +226,11 @@ export class ReputationClient {
     return this.parseReputationData(scValToNative(retval));
   }
 
+  /**
+   * Get a full reputation analysis including score, percentile, history, and recommendations.
+   * @param did - The DID or Stellar address to analyze
+   * @returns Comprehensive reputation analysis
+   */
   async getReputationAnalysis(did: string): Promise<ReputationScoreResult> {
     const [snapshot, history] = await Promise.all([
       this.getReputationScore(did),
@@ -251,6 +268,11 @@ export class ReputationClient {
     return { tier: 'Seedling', color: '#6B7280', description: 'Sybil-resistant base tier for new or lightly used accounts.' };
   }
 
+  /**
+   * Calculate the trend of reputation changes from historical data.
+   * @param history - Array of historical score values
+   * @returns Trend direction, absolute change, and percentage change
+   */
   calculateReputationTrend(history: number[]): { trend: 'up' | 'down' | 'stable'; change: number; percentage: number } {
     if (history.length < 2) return { trend: 'stable', change: 0, percentage: 0 };
     const recent = history.slice(-5);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Enumeration of supported zero-knowledge proof circuit types.
+ * @category Types
+ */
 export enum CircuitType {
   RangeProof = 'RangeProof',
   SetMembership = 'SetMembership',
@@ -6,6 +10,11 @@ export enum CircuitType {
   EqualityProof = 'EqualityProof',
 }
 
+/**
+ * W3C-compliant Decentralized Identifier (DID) document.
+ * Contains the DID's verification methods, services, and metadata.
+ * @category Types
+ */
 export interface DIDDocument {
 
   id: string;
@@ -30,6 +39,11 @@ export interface Service {
   endpoint: string;
 }
 
+/**
+ * W3C Verifiable Credential (VC) 2.0 data model.
+ * Represents a cryptographically signed credential issued by an authority.
+ * @category Types
+ */
 export interface VerifiableCredential {
   id: string;
   issuer: string;
@@ -122,6 +136,11 @@ export interface ReputationTierProof {
   generatedAt: number;
 }
 
+/**
+ * Zero-knowledge proof record stored on-chain.
+ * Contains proof data, circuit info, and verification metadata.
+ * @category Types
+ */
 export interface ZKProof {
   proofId: string;
   circuitId: string;
@@ -168,6 +187,11 @@ export interface NullifierRecord {
   proofId: string;
 }
 
+/**
+ * Compliance check record for a Stellar address.
+ * Tracks sanctions screening results and risk assessment.
+ * @category Types
+ */
 export interface ComplianceRecord {
   address: string;
   riskScore: number;
@@ -187,6 +211,25 @@ export interface SanctionsList {
   entries: string[];
 }
 
+/**
+ * Main configuration object for the Stellar Identity SDK.
+ * Specifies network, contract addresses, and RPC endpoints.
+ * @category Types
+ * @example
+ * ```typescript
+ * const config: StellarIdentityConfig = {
+ *   network: 'testnet',
+ *   contracts: {
+ *     didRegistry: '0x...',
+ *     credentialIssuer: '0x...',
+ *     reputationScore: '0x...',
+ *     zkAttestation: '0x...',
+ *     complianceFilter: '0x...'
+ *   },
+ *   rpcUrl: 'https://soroban-testnet.stellar.org'
+ * };
+ * ```
+ */
 export interface StellarIdentityConfig {
   network: 'mainnet' | 'testnet' | 'futurenet';
   contracts: {

--- a/sdk/src/zkProofs.ts
+++ b/sdk/src/zkProofs.ts
@@ -23,6 +23,12 @@ import {
 } from './types';
 import { StellarIdentityError, mapContractError } from './errors';
 
+/**
+ * Client for generating and verifying zero-knowledge proofs on Stellar.
+ * Supports age verification, income verification, KYC composite proofs,
+ * loan application proofs, and batch proof generation using snarkjs.
+ * @category Client
+ */
 export class ZKProofsClient {
   private rpc: SorobanRpc.Server;
   private config: StellarIdentityConfig;
@@ -101,6 +107,16 @@ export class ZKProofsClient {
   /**
    * Create high-level age proof
    */
+  /**
+   * Create an age verification zero-knowledge proof.
+   * Proves that the subject is at least `minAge` years old without revealing
+   * their actual birth year or age.
+   * @param birthYear - The subject's birth year
+   * @param currentYear - The current year for age calculation
+   * @param minAge - The minimum age threshold to prove
+   * @param options - Additional proof options including expiration
+   * @returns The generated proof ID
+   */
   async createAgeProof(
     birthYear: number,
     currentYear: number,
@@ -161,6 +177,15 @@ export class ZKProofsClient {
 
   /**
    * Create high-level income proof
+   */
+  /**
+   * Create an income verification zero-knowledge proof.
+   * Proves that the subject's income meets or exceeds `minIncome` without
+   * revealing the exact income amount.
+   * @param income - The subject's actual income
+   * @param minIncome - The minimum income threshold to prove
+   * @param options - Additional proof options including expiration
+   * @returns The generated proof ID
    */
   async createIncomeProof(
     income: number,
@@ -500,6 +525,13 @@ export class ZKProofsClient {
     }
   }
 
+  /**
+   * Submit a zero-knowledge proof to the on-chain contract.
+   * @param submitterKeypair - The keypair of the proof submitter
+   * @param options - Proof details including circuit, inputs, and proof bytes
+   * @param txOptions - Optional transaction parameters
+   * @returns The proof ID
+   */
   async submitProof(
     submitterKeypair: Keypair,
     options: ZKProofOptions,
@@ -759,6 +791,13 @@ export class ZKProofsClient {
     );
   }
 
+  /**
+   * Generate a cryptographic commitment using SHA-256.
+   * Used for hiding private data in zero-knowledge proofs.
+   * @param privateData - The data to commit to
+   * @param salt - Optional random salt (generated if not provided)
+   * @returns Hex-encoded commitment hash
+   */
   generateCommitment(privateData: string, salt?: string): string {
     const crypto = require('crypto') as typeof import('crypto');
     const actualSalt = salt ?? (crypto.randomBytes(32).toString('hex'));

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,45 @@
+{
+  "entryPoints": [
+    "sdk/src/index.ts",
+    "sdk/src/types.ts",
+    "sdk/src/errors.ts",
+    "sdk/src/didClient.ts",
+    "sdk/src/didResolver.ts",
+    "sdk/src/credentialClient.ts",
+    "sdk/src/reputation.ts",
+    "sdk/src/zkProofs.ts",
+    "sdk/src/compliance.ts",
+    "sdk/src/walletConnector.ts",
+    "sdk/src/cacheManager.ts",
+    "sdk/src/dataMinimization.ts",
+    "sdk/src/eventSubscriber.ts",
+    "sdk/src/logger.ts"
+  ],
+  "out": "docs/api",
+  "includeVersion": true,
+  "readme": "README.md",
+  "name": "Stellar Identity SDK",
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "excludeExternals": true,
+  "plugin": [],
+  "categorizeByGroup": true,
+  "categoryOrder": ["Client", "Types", "Errors", "Utilities", "*"],
+  "sort": ["source-order"],
+  "visibilityFilters": {
+    "protected": false,
+    "private": false,
+    "inherited": true,
+    "external": false
+  },
+  "navigation": {
+    "includeCategories": true,
+    "includeGroups": true
+  },
+  "highlightLanguages": ["typescript", "rust", "bash", "json"],
+  "githubPages": true,
+  "cleanOutputDir": true,
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #53: API Reference Documentation

### Changes
- Add JSDoc comments to all SDK public APIs (CredentialClient, DIDClient, ReputationClient, ZKProofsClient, types, errors)
- Configure Typedoc () for generating API documentation with category ordering
- Add documentation scripts to package.json (, , , , )
- Add  with ts-jest setup for SDK test infrastructure

### Files Changed
- `sdk/src/credentialClient.ts` - JSDoc for CredentialClient
- `sdk/src/didClient.ts` - JSDoc for DIDClient
- `sdk/src/errors.ts` - JSDoc for error classes
- `sdk/src/index.ts` - JSDoc for StellarIdentitySDK
- `sdk/src/reputation.ts` - JSDoc for ReputationClient
- `sdk/src/types.ts` - JSDoc for types
- `sdk/src/zkProofs.ts` - JSDoc for ZKProofsClient
- `typedoc.json` - Typedoc configuration
- `jest.config.js` - Jest test configuration
- `package.json` - Documentation scripts + typedoc devDependency