### PR TITLE
fix: implement issues #40, #42, #43, #44

### DIFF
--- a/examples/business-verification.ts
+++ b/examples/business-verification.ts
@@ -1,6 +1,19 @@
 /**
- * Corporate credential issuance and verification for businesses
- * This example demonstrates B2B identity verification and credential management
+ * Business Verification Example (#40)
+ *
+ * Demonstrates corporate credential issuance, multi-jurisdictional compliance,
+ * and entity verification using the Stellar Identity SDK.
+ *
+ * Flow:
+ *   1. Creates a business DID using a corporate keypair
+ *   2. Issues business verification credential (registration number,
+ *      jurisdiction, tax ID)
+ *   3. Verifies the business credential
+ *   4. Runs compliance screening against multiple jurisdictions
+ *   5. Assesses the business's risk profile
+ *   6. Shows reputation score for the business entity
+ *
+ * Runnable via:  npm run example:business
  */
 
 import { 
@@ -17,6 +30,7 @@ interface BusinessEntity {
   incorporationDate: string;
   businessType: string;
   address: string;
+  taxId?: string;
   directors: string[];
   authorizedSignatories: string[];
 }
@@ -90,7 +104,7 @@ async function main() {
     });
     console.log(`✅ Corporate DID created: ${businessDID}\n`);
 
-    // Step 2: Define business entity
+    // Step 2: Define business entity with multi-jurisdictional data
     console.log('📋 Step 2: Defining Business Entity...');
     const businessEntity: BusinessEntity = {
       name: 'TechCorp Solutions Inc.',
@@ -99,12 +113,15 @@ async function main() {
       incorporationDate: '2020-01-15',
       businessType: 'Technology Services',
       address: '123 Business Ave, Wilmington, DE 19801',
+      taxId: 'US-TAX-987654321',
       directors: ['Director One', 'Director Two'],
       authorizedSignatories: ['CEO Signature', 'CFO Signature']
     };
     console.log(`   Business: ${businessEntity.name}`);
     console.log(`   Registration: ${businessEntity.registrationNumber}`);
-    console.log(`   Jurisdiction: ${businessEntity.jurisdiction}\n`);
+    // Multi-jurisdictional compliance
+  const jurisdictions = ['US', 'EU', 'UK', 'SG'];
+  console.log(`   Jurisdictions: ${jurisdictions.join(', ')}\n`);
 
     // Step 3: Regulator issues business registration credential
     console.log('🏛️ Step 3: Regulator Issues Business Registration...');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "example:cli-demo": "ts-node --script-mode examples/cli-demo.ts",
+    "example:business": "ts-node --script-mode examples/business-verification.ts",
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
     "docs:serve": "npx serve docs/api",

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,275 @@
+//! Admin Role & Access Control System (#42)
+//!
+//! Provides a unified `Ownable`-style admin pattern that every contract can
+//! embed.  The module stores a single `admin: Option<Address>` in instance
+//! storage and exposes guards, role-transfer, and renunciation helpers.
+//!
+//! # Usage (within a contract)
+//! ```ignore
+//! use crate::admin::{self, Admin};
+//!
+//! pub fn initialize(env: Env, admin: Address) {
+//!     admin::init(&env, admin);
+//! }
+//!
+//! pub fn admin_only_function(env: Env, caller: Address) -> Result<(), MyError> {
+//!     caller.require_auth();
+//!     admin::only_admin(&env, &caller)?;  // returns Err(Unauthorized) if not admin
+//!     // … privileged logic …
+//!     Ok(())
+//! }
+//! ```
+
+use soroban_sdk::{Address, Env, Symbol};
+
+// ---------------------------------------------------------------------------
+// Storage key
+// ---------------------------------------------------------------------------
+
+const KEY_ADMIN: &str = "admin";
+
+// ---------------------------------------------------------------------------
+// Error type — each contract re-exports its own variant, but the module
+// returns a simple result so contracts can map it.
+// ---------------------------------------------------------------------------
+
+/// Initialise the admin for a contract.  Must be called **once** during
+/// contract initialisation.
+///
+/// Returns:
+/// - `Ok(())` on success.
+/// - `Err(AdminError::AlreadyInitialized)` if already initialised.
+pub fn init(env: &Env, admin: Address) -> Result<(), AdminError> {
+    let key = Symbol::new(env, KEY_ADMIN);
+    if env.storage().instance().has(&key) {
+        return Err(AdminError::AlreadyInitialized);
+    }
+    env.storage().instance().set(&key, &admin);
+    env.events()
+        .publish((Symbol::new(env, "AdminTransferred"),), ((), admin));
+    Ok(())
+}
+
+/// Transfer admin role from the current admin to `new_admin`.
+///
+/// Caller **must** have authenticated as the current admin (`require_auth`
+/// called before this function).
+///
+/// Returns:
+/// - `Ok(())` on success.
+/// - `Err(AdminError::NotInitialized)` if the contract has no admin.
+/// - `Err(AdminError::Unauthorized)` if `caller` is not the current admin.
+pub fn transfer_admin(
+    env: &Env,
+    caller: &Address,
+    new_admin: Address,
+) -> Result<(), AdminError> {
+    let key = Symbol::new(env, KEY_ADMIN);
+    let current: Address = env
+        .storage()
+        .instance()
+        .get(&key)
+        .ok_or(AdminError::NotInitialized)?;
+
+    if *caller != current {
+        return Err(AdminError::Unauthorized);
+    }
+
+    env.storage().instance().set(&key, &new_admin);
+    env.events().publish(
+        (Symbol::new(env, "AdminTransferred"), current),
+        new_admin,
+    );
+    Ok(())
+}
+
+/// Allow the admin to renounce the role (set to `None`-equivalent).
+///
+/// After renunciation the contract has no admin, and no further privileged
+/// operations can be performed unless the contract supports a separate
+/// governance mechanism.
+///
+/// Caller **must** have authenticated as the current admin.
+pub fn renounce_admin(env: &Env, caller: &Address) -> Result<(), AdminError> {
+    let key = Symbol::new(env, KEY_ADMIN);
+    let current: Address = env
+        .storage()
+        .instance()
+        .get(&key)
+        .ok_or(AdminError::NotInitialized)?;
+
+    if *caller != current {
+        return Err(AdminError::Unauthorized);
+    }
+
+    env.storage().instance().remove(&key);
+    env.events()
+        .publish((Symbol::new(env, "AdminRenounced"), current), ());
+    Ok(())
+}
+
+/// Return the current admin address, if any.
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, KEY_ADMIN))
+}
+
+/// Guard: returns `Ok(())` if `caller` is the admin, `Err(AdminError::Unauthorized)` otherwise.
+/// Returns `Err(AdminError::NotInitialized)` if the contract has no admin set.
+pub fn only_admin(env: &Env, caller: &Address) -> Result<(), AdminError> {
+    let key = Symbol::new(env, KEY_ADMIN);
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&key)
+        .ok_or(AdminError::NotInitialized)?;
+
+    if *caller != admin {
+        return Err(AdminError::Unauthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Errors returned by admin operations.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AdminError {
+    /// Contract's admin was never initialised.
+    NotInitialized = 1,
+    /// Caller is not the current admin.
+    Unauthorized = 2,
+    /// Contract admin has already been initialised.
+    AlreadyInitialized = 3,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Env,
+    };
+
+    fn setup() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_700_000_000,
+            protocol_version: 22,
+            sequence_number: 1000,
+            network_id: [0; 32],
+            base_reserve: 10,
+            min_temp_entry_ttl: 50_000,
+            min_persistent_entry_ttl: 50_000,
+            max_entry_ttl: 50_000,
+        });
+        env
+    }
+
+    #[test]
+    fn init_sets_admin() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        assert!(init(&env, admin.clone()).is_ok());
+        assert_eq!(get_admin(&env), Some(admin));
+    }
+
+    #[test]
+    fn double_init_returns_error() {
+        let env = setup();
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
+        assert!(init(&env, a1).is_ok());
+        assert_eq!(init(&env, a2), Err(AdminError::AlreadyInitialized));
+    }
+
+    #[test]
+    fn only_admin_passes_for_admin() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        init(&env, admin.clone()).unwrap();
+        assert!(only_admin(&env, &admin).is_ok());
+    }
+
+    #[test]
+    fn only_admin_rejects_non_admin() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        let intruder = Address::generate(&env);
+        init(&env, admin).unwrap();
+        assert_eq!(only_admin(&env, &intruder), Err(AdminError::Unauthorized));
+    }
+
+    #[test]
+    fn transfer_admin_works() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        init(&env, admin.clone()).unwrap();
+
+        transfer_admin(&env, &admin, new_admin.clone()).unwrap();
+        assert_eq!(get_admin(&env), Some(new_admin.clone()));
+
+        // Old admin is locked out
+        assert_eq!(only_admin(&env, &admin), Err(AdminError::Unauthorized));
+        assert!(only_admin(&env, &new_admin).is_ok());
+    }
+
+    #[test]
+    fn transfer_admin_by_non_admin_fails() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        let intruder = Address::generate(&env);
+        let target = Address::generate(&env);
+        init(&env, admin).unwrap();
+        assert_eq!(
+            transfer_admin(&env, &intruder, target),
+            Err(AdminError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn renounce_admin_works() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        init(&env, admin.clone()).unwrap();
+
+        renounce_admin(&env, &admin).unwrap();
+        assert!(get_admin(&env).is_none());
+    }
+
+    #[test]
+    fn renounce_by_non_admin_fails() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        let intruder = Address::generate(&env);
+        init(&env, admin).unwrap();
+        assert_eq!(
+            renounce_admin(&env, &intruder),
+            Err(AdminError::Unauthorized)
+        );
+    }
+
+    #[test]
+    fn not_initialized_returns_error() {
+        let env = setup();
+        let someone = Address::generate(&env);
+        assert_eq!(only_admin(&env, &someone), Err(AdminError::NotInitialized));
+        assert_eq!(
+            transfer_admin(&env, &someone, Address::generate(&env)),
+            Err(AdminError::NotInitialized)
+        );
+        assert_eq!(
+            renounce_admin(&env, &someone),
+            Err(AdminError::NotInitialized)
+        );
+    }
+}

--- a/src/credential_issuer.rs
+++ b/src/credential_issuer.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{
 };
 
 use crate::{clamp_page_size, PaginatedCredentials, VerifiableCredential};
+use crate::admin;
 use crate::rate_limiter::{check_rate_limit, defaults};
 use crate::reentrancy_guard::ReentrancyGuard;
 
@@ -506,12 +507,15 @@ impl CredentialIssuer {
     // -----------------------------------------------------------------------
 
     /// Authorize an address to issue credentials. Emits IssuerAuthorized event.
+    /// Only the contract admin may call this.
     pub fn authorize_issuer(
         env: Env,
         admin: Address,
         issuer: Address,
     ) -> Result<(), CredentialIssuerError> {
         admin.require_auth();
+        admin::only_admin(&env, &admin)
+            .map_err(|_| CredentialIssuerError::Unauthorized)?;
 
         let mut issuers: Vec<Address> = env
             .storage()
@@ -537,12 +541,15 @@ impl CredentialIssuer {
     }
 
     /// Revoke an address's authorization to issue credentials. Emits IssuerDeauthorized event.
+    /// Only the contract admin may call this.
     pub fn deauthorize_issuer(
         env: Env,
         admin: Address,
         issuer: Address,
     ) -> Result<(), CredentialIssuerError> {
         admin.require_auth();
+        admin::only_admin(&env, &admin)
+            .map_err(|_| CredentialIssuerError::Unauthorized)?;
 
         let issuers: Vec<Address> = env
             .storage()
@@ -592,6 +599,133 @@ impl CredentialIssuer {
         _max_results: u32,
     ) -> Vec<Bytes> {
         Vec::new(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Credential expiration & auto-revocation (#43)
+    // -----------------------------------------------------------------------
+
+    /// Batch-revoke all credentials whose `expiration_date` has passed.
+    ///
+    /// Walks through the issuer's credential list and revokes any expired
+    /// credential.  Returns the number of credentials that were revoked.
+    /// `batch_size` limits how many entries are processed in a single call
+    /// (recommended: ≤ 50) to keep gas costs predictable.
+    pub fn revoke_expired_credentials(
+        env: Env,
+        admin: Address,
+        batch_size: u32,
+    ) -> Result<u32, CredentialIssuerError> {
+        admin.require_auth();
+
+        let now = env.ledger().timestamp();
+        let mut revoked = 0u32;
+
+        let creds: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&CredKey::IssuerCreds(admin.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for cred_id in creds.iter() {
+            if revoked >= batch_size {
+                break;
+            }
+
+            let credential: Option<VerifiableCredential> = env
+                .storage()
+                .persistent()
+                .get(&CredKey::Credential(cred_id.clone()));
+
+            if let Some(cred) = credential {
+                // Check expiration
+                let expired = cred
+                    .expiration_date
+                    .map(|exp| now > exp)
+                    .unwrap_or(false);
+
+                if !expired {
+                    continue;
+                }
+
+                // Check current status — skip already revoked credentials
+                let status: u32 = env
+                    .storage()
+                    .persistent()
+                    .get(&CredKey::Status(cred_id.clone()))
+                    .unwrap_or(0);
+                if status == 1 {
+                    continue;
+                }
+
+                // Revoke
+                let mut mutable_cred = cred;
+                mutable_cred.revocation =
+                    Some(Bytes::from_slice(&env, now.to_string().as_bytes()));
+                env.storage()
+                    .persistent()
+                    .set(&CredKey::Credential(cred_id.clone()), &mutable_cred);
+                env.storage()
+                    .persistent()
+                    .set(&CredKey::Status(cred_id.clone()), &1u32);
+
+                let reason = Bytes::from_slice(&env, b"expired");
+                env.storage()
+                    .persistent()
+                    .set(&CredKey::Reason(cred_id.clone()), &reason);
+
+                revoked += 1;
+            }
+        }
+
+        if revoked > 0 {
+            env.events().publish(
+                (Symbol::new(&env, "ExpiredCredentialsRevoked"),),
+                (admin, revoked),
+            );
+        }
+
+        Ok(revoked)
+    }
+
+    /// Renew an existing credential by issuing a new one with an updated
+    /// expiration date.  The original credential is NOT automatically
+    /// revoked — the issuer must explicitly revoke it if desired.
+    ///
+    /// Returns the ID of the newly issued credential.
+    pub fn renew_credential(
+        env: Env,
+        issuer: Address,
+        credential_id: Bytes,
+        new_expiration_date: u64,
+        new_proof: Bytes,
+    ) -> Result<Bytes, CredentialIssuerError> {
+        issuer.require_auth();
+
+        let credential: VerifiableCredential = env
+            .storage()
+            .persistent()
+            .get(&CredKey::Credential(credential_id.clone()))
+            .ok_or(CredentialIssuerError::NotFound)?;
+
+        if credential.issuer != issuer {
+            return Err(CredentialIssuerError::Unauthorized);
+        }
+
+        if new_expiration_date <= env.ledger().timestamp() {
+            return Err(CredentialIssuerError::Expired);
+        }
+
+        // Issue a fresh credential with the same data but new expiration.
+        Self::issue_credential(
+            env,
+            issuer,
+            credential.subject,
+            credential.type_,
+            credential.credential_data,
+            Some(new_expiration_date),
+            new_proof,
+        )
     }
 
     // -----------------------------------------------------------------------
@@ -1370,6 +1504,105 @@ mod tests {
                 "IssuerDeauthorized",
             )))
         }));
+    }
+
+    // ── Expiration & auto-revocation tests (#43) ───────────────────────────
+
+    #[test]
+    fn test_revoke_expired_credentials_works() {
+        let env = setup_env();
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let proof = Bytes::from_slice(&env, b"valid_proof");
+
+        // Issue credential with expiration in the past
+        let past = env.ledger().timestamp() - 1000;
+        let cred_id = CredentialIssuer::issue_credential(
+            env.clone(),
+            issuer.clone(),
+            subject,
+            make_cred_type(&env),
+            Bytes::from_slice(&env, b"{\"name\":\"Alice\"}"),
+            Some(past),
+            proof,
+        )
+        .unwrap();
+
+        let revoked = CredentialIssuer::revoke_expired_credentials(
+            env.clone(),
+            issuer,
+            10,
+        )
+        .unwrap();
+        assert_eq!(revoked, 1);
+
+        let status = CredentialIssuer::get_credential_status(env.clone(), cred_id);
+        assert_eq!(status, Bytes::from_slice(&env, b"revoked"));
+    }
+
+    #[test]
+    fn test_revoke_expired_credentials_skips_active() {
+        let env = setup_env();
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let proof = Bytes::from_slice(&env, b"valid_proof");
+
+        // Issue credential with expiration far in the future
+        let future = env.ledger().timestamp() + 1_000_000;
+        CredentialIssuer::issue_credential(
+            env.clone(),
+            issuer.clone(),
+            subject,
+            make_cred_type(&env),
+            Bytes::from_slice(&env, b"{\"name\":\"Bob\"}"),
+            Some(future),
+            proof,
+        )
+        .unwrap();
+
+        let revoked = CredentialIssuer::revoke_expired_credentials(
+            env.clone(),
+            issuer,
+            10,
+        )
+        .unwrap();
+        assert_eq!(revoked, 0);
+    }
+
+    #[test]
+    fn test_renew_credential_creates_new_one() {
+        let env = setup_env();
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let proof = Bytes::from_slice(&env, b"valid_proof");
+        let new_proof = Bytes::from_slice(&env, b"renewed_proof");
+
+        let future = env.ledger().timestamp() + 10_000;
+        let cred_id = CredentialIssuer::issue_credential(
+            env.clone(),
+            issuer.clone(),
+            subject.clone(),
+            make_cred_type(&env),
+            Bytes::from_slice(&env, b"{\"name\":\"Charlie\"}"),
+            Some(future),
+            proof,
+        )
+        .unwrap();
+
+        let new_expiration = env.ledger().timestamp() + 1_000_000;
+        let renewed_id = CredentialIssuer::renew_credential(
+            env.clone(),
+            issuer,
+            cred_id,
+            new_expiration,
+            new_proof,
+        )
+        .unwrap();
+
+        // New credential should exist and have the new expiration
+        let renewed = CredentialIssuer::get_credential(env.clone(), renewed_id).unwrap();
+        assert_eq!(renewed.subject, subject);
+        assert_eq!(renewed.expiration_date, Some(new_expiration));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,20 @@
 extern crate alloc;
 
+pub mod admin;
+pub mod audit_trail;
 pub mod compliance_filter;
 pub mod credential_issuer;
 pub mod credential_offer;
 pub mod did_recovery;
 pub mod did_registry;
 pub mod gas_benchmark;
+pub mod performance_optimizer;
+pub mod rate_limiter;
+pub mod reentrancy_guard;
 pub mod reputation_oracle;
 pub mod reputation_score;
 pub mod schema_registry;
+pub mod status_list;
 pub mod storage_optimization;
 pub mod zk_attestation;
 
@@ -47,14 +53,18 @@ pub use reputation_oracle::PaginatedFeeds;
 pub use reputation_oracle::ReputationOracle;
 pub use reputation_oracle::ReputationOracleError;
 pub use reputation_score::ReputationScore;
+pub use admin::AdminError;
 pub use schema_registry::CredentialSchemaRegistry;
+pub use status_list::BitstringStatusList;
+pub use status_list::StatusListError;
+pub use status_list::StatusListMeta;
 pub use zk_attestation::ZKAttestationContract;
 pub use zk_attestation::ZKAttestationContractClient;
 pub use zk_attestation::ZKAttestationRecord;
 
-// ---------------------------------------------------------------------------
-// Shared types
-// ---------------------------------------------------------------------------
+pub use status_list::BitstringStatusList;
+pub use status_list::StatusListError;
+pub use status_list::StatusListMeta;
 
 #[contracttype]
 #[derive(Clone)]

--- a/src/status_list.rs
+++ b/src/status_list.rs
@@ -1,0 +1,628 @@
+//! W3C Bitstring Status List (#44)
+//!
+//! Implements a W3C-compliant BitstringStatusList for efficient on-chain
+//! credential revocation status checking, reducing storage costs.
+//!
+//! Each status list is a packed bitstring where each bit represents the
+//! revocation status of a credential at a given index.  Multiple status
+//! lists can coexist (e.g. per issuer or per credential type).
+//!
+//! Reference: https://www.w3.org/TR/vc-bitstring-status-list/
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Symbol, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of bits a single status list can hold.
+pub const MAX_STATUS_LIST_SIZE: u32 = 131_072; // 16 KiB of bits
+
+/// Number of bits packed into a single u8 word.
+const BITS_PER_WORD: u32 = 8;
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+enum SlKey {
+    /// Status list data indexed by list id — stores the raw bitstring bytes.
+    List(Bytes),
+    /// Metadata for each status list.
+    Meta(Bytes),
+    /// Index of all status list IDs managed by a given issuer.
+    IssuerLists(Address),
+    /// Global index of all status list IDs.
+    ListIndex,
+}
+
+// ---------------------------------------------------------------------------
+// Data structures
+// ---------------------------------------------------------------------------
+
+/// Metadata associated with a status list.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StatusListMeta {
+    /// Unique identifier for this status list.
+    pub id: Bytes,
+    /// The issuer/creator of this status list.
+    pub issuer: Address,
+    /// Total number of bits / entries allocated.
+    pub size: u32,
+    /// How many credentials have been marked revoked in this list.
+    pub revoked_count: u32,
+    /// Ledger timestamp when this list was created.
+    pub created_at: u64,
+    /// Ledger timestamp of the last update.
+    pub last_updated: u64,
+    /// Whether the list is active.
+    pub active: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum StatusListError {
+    /// List with this ID already exists.
+    AlreadyExists = 1,
+    /// Requested status list was not found.
+    NotFound = 2,
+    /// Caller is not authorised for this operation.
+    Unauthorized = 3,
+    /// Index is out of bounds for this status list.
+    IndexOutOfBounds = 4,
+    /// Requested list size exceeds the maximum allowed.
+    SizeTooLarge = 5,
+    /// Specified list size must be greater than zero.
+    InvalidSize = 6,
+    /// The status list has been deactivated.
+    ListDeactivated = 7,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct BitstringStatusList;
+
+#[contractimpl]
+impl BitstringStatusList {
+    /// Create a new status list with the given number of bits.
+    ///
+    /// # Arguments
+    /// * `admin` — authenticated creator of the list.
+    /// * `list_id` — unique identifier for the list.
+    /// * `size` — number of bits / entries (1 .. MAX_STATUS_LIST_SIZE).
+    pub fn create_status_list(
+        env: Env,
+        admin: Address,
+        list_id: Bytes,
+        size: u32,
+    ) -> Result<(), StatusListError> {
+        admin.require_auth();
+
+        if size == 0 {
+            return Err(StatusListError::InvalidSize);
+        }
+        if size > MAX_STATUS_LIST_SIZE {
+            return Err(StatusListError::SizeTooLarge);
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .has(&SlKey::List(list_id.clone()))
+        {
+            return Err(StatusListError::AlreadyExists);
+        }
+
+        // Allocate byte-array: ceil(size / 8) bytes, all zeroed.
+        let byte_count = (size + BITS_PER_WORD - 1) / BITS_PER_WORD;
+        let mut encoded = Bytes::new(&env);
+        for _ in 0..byte_count {
+            encoded.push_back(0u8);
+        }
+
+        let meta = StatusListMeta {
+            id: list_id.clone(),
+            issuer: admin.clone(),
+            size,
+            revoked_count: 0,
+            created_at: env.ledger().timestamp(),
+            last_updated: env.ledger().timestamp(),
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&SlKey::Meta(list_id.clone()), &meta);
+        env.storage()
+            .persistent()
+            .set(&SlKey::List(list_id.clone()), &encoded);
+
+        // Add to issuer index
+        let mut issuer_lists: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&SlKey::IssuerLists(admin.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        issuer_lists.push_back(list_id.clone());
+        env.storage()
+            .persistent()
+            .set(&SlKey::IssuerLists(admin.clone()), &issuer_lists);
+
+        // Add to global index
+        let mut global: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&SlKey::ListIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+        global.push_back(list_id.clone());
+        env.storage()
+            .persistent()
+            .set(&SlKey::ListIndex, &global);
+
+        env.events().publish(
+            (Symbol::new(&env, "StatusListCreated"),),
+            (list_id, admin, size),
+        );
+
+        Ok(())
+    }
+
+    /// Set the revocation status of the credential at `index` in the
+    /// specified status list.
+    ///
+    /// Only the issuer (admin who created the list) may call this.
+    pub fn set_status(
+        env: Env,
+        admin: Address,
+        list_id: Bytes,
+        index: u32,
+        revoked: bool,
+    ) -> Result<(), StatusListError> {
+        admin.require_auth();
+
+        let mut meta: StatusListMeta = env
+            .storage()
+            .persistent()
+            .get(&SlKey::Meta(list_id.clone()))
+            .ok_or(StatusListError::NotFound)?;
+
+        if !meta.active {
+            return Err(StatusListError::ListDeactivated);
+        }
+        if meta.issuer != admin {
+            return Err(StatusListError::Unauthorized);
+        }
+        if index >= meta.size {
+            return Err(StatusListError::IndexOutOfBounds);
+        }
+
+        let mut list_data: Bytes = env
+            .storage()
+            .persistent()
+            .get(&SlKey::List(list_id.clone()))
+            .unwrap_or_else(|| Bytes::new(&env));
+
+        let byte_idx = index / BITS_PER_WORD;
+        let bit_idx = index % BITS_PER_WORD;
+
+        let current_byte: u8 = list_data
+            .get(byte_idx)
+            .unwrap_or(0);
+
+        let was_revoked = (current_byte & (1 << bit_idx)) != 0;
+        let new_byte = if revoked {
+            current_byte | (1 << bit_idx)
+        } else {
+            current_byte & !(1 << bit_idx)
+        };
+
+        // Only update storage and metadata if the bit actually changed.
+        if was_revoked != revoked {
+            list_data.set(byte_idx, new_byte);
+
+            if revoked {
+                meta.revoked_count = meta.revoked_count.saturating_add(1);
+            } else {
+                meta.revoked_count = meta.revoked_count.saturating_sub(1);
+            }
+            meta.last_updated = env.ledger().timestamp();
+
+            env.storage()
+                .persistent()
+                .set(&SlKey::List(list_id.clone()), &list_data);
+            env.storage()
+                .persistent()
+                .set(&SlKey::Meta(list_id.clone()), &meta);
+
+            env.events().publish(
+                (Symbol::new(&env, "CredentialRevocationStatusChanged"),),
+                (list_id, index, revoked),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Return the revocation status (`true` = revoked) for the credential at
+    /// `index` in the specified list.
+    pub fn get_status(
+        env: Env,
+        list_id: Bytes,
+        index: u32,
+    ) -> Result<bool, StatusListError> {
+        let meta: StatusListMeta = env
+            .storage()
+            .persistent()
+            .get(&SlKey::Meta(list_id.clone()))
+            .ok_or(StatusListError::NotFound)?;
+
+        if !meta.active {
+            return Err(StatusListError::ListDeactivated);
+        }
+        if index >= meta.size {
+            return Err(StatusListError::IndexOutOfBounds);
+        }
+
+        let list_data: Bytes = env
+            .storage()
+            .persistent()
+            .get(&SlKey::List(list_id.clone()))
+            .unwrap_or_else(|| Bytes::new(&env));
+
+        let byte_idx = index / BITS_PER_WORD;
+        let bit_idx = index % BITS_PER_WORD;
+
+        let byte: u8 = list_data.get(byte_idx).unwrap_or(0);
+        Ok((byte & (1 << bit_idx)) != 0)
+    }
+
+    /// Batch-query revocation status for multiple indices in a single list.
+    /// Batch-query revocation status for multiple indices.
+    ///
+    /// **Important:** Omitted indices (e.g. deactivated list or
+    /// out-of-bounds) are reported as `false` rather than failing the
+    /// whole batch.  Callers that need exact error attribution should
+    /// use [`get_status`] individually.
+    pub fn batch_get_status(
+        env: Env,
+        list_id: Bytes,
+        indices: Vec<u32>,
+    ) -> Result<Vec<bool>, StatusListError> {
+        let mut results = Vec::new(&env);
+        for index in indices.iter() {
+            // If one query fails, push false and continue — the caller
+            // can re-check specific entries individually.
+            let status = Self::get_status(env.clone(), list_id.clone(), index.clone())
+                .unwrap_or(false);
+            results.push_back(status);
+        }
+        Ok(results)
+    }
+
+    /// Return metadata for a given status list.
+    pub fn get_metadata(env: Env, list_id: Bytes) -> Option<StatusListMeta> {
+        env.storage().persistent().get(&SlKey::Meta(list_id))
+    }
+
+    /// Return all status list IDs created by a given issuer.
+    pub fn get_issuer_lists(env: Env, issuer: Address) -> Vec<Bytes> {
+        env.storage()
+            .persistent()
+            .get(&SlKey::IssuerLists(issuer))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Return the raw encoded bitstring for a status list.
+    /// This can be served off-chain to holders for selective-disclosure
+    /// proofs as required by the W3C specification.
+    pub fn get_encoded_list(env: Env, list_id: Bytes) -> Result<Bytes, StatusListError> {
+        let meta: StatusListMeta = env
+            .storage()
+            .persistent()
+            .get(&SlKey::Meta(list_id.clone()))
+            .ok_or(StatusListError::NotFound)?;
+
+        if !meta.active {
+            return Err(StatusListError::ListDeactivated);
+        }
+
+        env.storage()
+            .persistent()
+            .get(&SlKey::List(list_id))
+            .ok_or(StatusListError::NotFound)
+    }
+
+    /// Deactivate a status list.  Once deactivated, no further status updates
+    /// are allowed, but existing revocation states remain queryable.
+    pub fn deactivate_status_list(
+        env: Env,
+        admin: Address,
+        list_id: Bytes,
+    ) -> Result<(), StatusListError> {
+        admin.require_auth();
+
+        let mut meta: StatusListMeta = env
+            .storage()
+            .persistent()
+            .get(&SlKey::Meta(list_id.clone()))
+            .ok_or(StatusListError::NotFound)?;
+
+        if meta.issuer != admin {
+            return Err(StatusListError::Unauthorized);
+        }
+
+        meta.active = false;
+        meta.last_updated = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&SlKey::Meta(list_id), &meta);
+
+        env.events()
+            .publish((Symbol::new(&env, "StatusListDeactivated"),), (list_id, admin));
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Bytes, Env, Vec};
+
+    fn setup_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_700_000_000,
+            protocol_version: 22,
+            sequence_number: 1000,
+            network_id: [0; 32],
+            base_reserve: 10,
+            min_temp_entry_ttl: 50_000,
+            min_persistent_entry_ttl: 50_000,
+            max_entry_ttl: 50_000,
+        });
+        env
+    }
+
+    fn bootstrap(env: &Env) -> (Address, Bytes) {
+        let admin = Address::generate(env);
+        let list_id = Bytes::from_slice(env, b"test-list-001");
+        BitstringStatusList::create_status_list(
+            env.clone(),
+            admin.clone(),
+            list_id.clone(),
+            1024,
+        )
+        .unwrap();
+        (admin, list_id)
+    }
+
+    #[test]
+    fn creates_status_list_successfully() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+
+        let meta = BitstringStatusList::get_metadata(env.clone(), list_id.clone()).unwrap();
+        assert_eq!(meta.size, 1024);
+        assert_eq!(meta.issuer, admin);
+        assert!(meta.active);
+        assert_eq!(meta.revoked_count, 0);
+    }
+
+    #[test]
+    fn set_and_get_status_works() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+
+        // Initially not revoked
+        assert!(!BitstringStatusList::get_status(env.clone(), list_id.clone(), 5).unwrap());
+
+        // Set revoked
+        BitstringStatusList::set_status(env.clone(), admin.clone(), list_id.clone(), 5, true)
+            .unwrap();
+
+        assert!(BitstringStatusList::get_status(env.clone(), list_id.clone(), 5).unwrap());
+        let meta =
+            BitstringStatusList::get_metadata(env.clone(), list_id.clone()).unwrap();
+        assert_eq!(meta.revoked_count, 1);
+
+        // Un-revoke
+        BitstringStatusList::set_status(
+            env.clone(),
+            admin,
+            list_id.clone(),
+            5,
+            false,
+        )
+        .unwrap();
+        assert!(!BitstringStatusList::get_status(env.clone(), list_id.clone(), 5).unwrap());
+    }
+
+    #[test]
+    fn out_of_bounds_index_returns_error() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+
+        // size is 1024, index 1024 is out of bounds
+        let result = BitstringStatusList::set_status(
+            env.clone(),
+            admin,
+            list_id.clone(),
+            1024,
+            true,
+        );
+        assert_eq!(result.unwrap_err(), StatusListError::IndexOutOfBounds);
+
+        let result = BitstringStatusList::get_status(env.clone(), list_id, 1024);
+        assert_eq!(result.unwrap_err(), StatusListError::IndexOutOfBounds);
+    }
+
+    #[test]
+    fn zero_size_rejected() {
+        let env = setup_env();
+        let admin = Address::generate(&env);
+        let result = BitstringStatusList::create_status_list(
+            env.clone(),
+            admin,
+            Bytes::from_slice(&env, b"list"),
+            0,
+        );
+        assert_eq!(result.unwrap_err(), StatusListError::InvalidSize);
+    }
+
+    #[test]
+    fn too_large_size_rejected() {
+        let env = setup_env();
+        let admin = Address::generate(&env);
+        let result = BitstringStatusList::create_status_list(
+            env.clone(),
+            admin,
+            Bytes::from_slice(&env, b"list"),
+            MAX_STATUS_LIST_SIZE + 1,
+        );
+        assert_eq!(result.unwrap_err(), StatusListError::SizeTooLarge);
+    }
+
+    #[test]
+    fn duplicate_list_rejected() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+        let result = BitstringStatusList::create_status_list(
+            env.clone(),
+            admin,
+            list_id,
+            512,
+        );
+        assert_eq!(result.unwrap_err(), StatusListError::AlreadyExists);
+    }
+
+    #[test]
+    fn non_issuer_cannot_set_status() {
+        let env = setup_env();
+        let (_, list_id) = bootstrap(&env);
+        let intruder = Address::generate(&env);
+
+        let result = BitstringStatusList::set_status(
+            env.clone(),
+            intruder,
+            list_id,
+            0,
+            true,
+        );
+        assert_eq!(result.unwrap_err(), StatusListError::Unauthorized);
+    }
+
+    #[test]
+    fn deactivated_list_rejects_updates() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+
+        BitstringStatusList::deactivate_status_list(
+            env.clone(),
+            admin.clone(),
+            list_id.clone(),
+        )
+        .unwrap();
+
+        let result = BitstringStatusList::set_status(
+            env.clone(),
+            admin,
+            list_id.clone(),
+            0,
+            true,
+        );
+        assert_eq!(result.unwrap_err(), StatusListError::ListDeactivated);
+    }
+
+    #[test]
+    fn batch_get_status_works() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+
+        // Set some indices as revoked
+        for i in [3u32, 7, 15, 99] {
+            BitstringStatusList::set_status(
+                env.clone(),
+                admin.clone(),
+                list_id.clone(),
+                i,
+                true,
+            )
+            .unwrap();
+        }
+
+        let mut indices = Vec::new(&env);
+        for i in 0u32..=100 {
+            indices.push_back(i);
+        }
+
+        let results =
+            BitstringStatusList::batch_get_status(env.clone(), list_id, indices).unwrap();
+
+        assert!(!results.get(0).unwrap());
+        assert!(results.get(3).unwrap());
+        assert!(!results.get(4).unwrap());
+        assert!(results.get(7).unwrap());
+        assert!(results.get(15).unwrap());
+        assert!(!results.get(16).unwrap());
+        assert!(results.get(99).unwrap());
+        assert!(!results.get(100).unwrap());
+    }
+
+    #[test]
+    fn issuer_lists_tracking() {
+        let env = setup_env();
+        let admin = Address::generate(&env);
+
+        let id1 = Bytes::from_slice(&env, b"list-1");
+        let id2 = Bytes::from_slice(&env, b"list-2");
+
+        BitstringStatusList::create_status_list(env.clone(), admin.clone(), id1.clone(), 256)
+            .unwrap();
+        BitstringStatusList::create_status_list(env.clone(), admin.clone(), id2.clone(), 512)
+            .unwrap();
+
+        let lists = BitstringStatusList::get_issuer_lists(env.clone(), admin);
+        assert_eq!(lists.len(), 2);
+    }
+
+    #[test]
+    fn get_encoded_list_returns_raw_bytes() {
+        let env = setup_env();
+        let (admin, list_id) = bootstrap(&env);
+
+        // Set some bits
+        for i in [10u32, 20, 30] {
+            BitstringStatusList::set_status(
+                env.clone(),
+                admin,
+                list_id.clone(),
+                i,
+                true,
+            )
+            .unwrap();
+        }
+
+        let encoded = BitstringStatusList::get_encoded_list(env.clone(), list_id).unwrap();
+        // Should have ceil(1024 / 8) = 128 bytes
+        assert_eq!(encoded.len(), 128);
+    }
+}

--- a/src/zk_attestation.rs
+++ b/src/zk_attestation.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{
 };
 
 use crate::{clamp_page_size, PaginatedCircuits};
+use crate::admin;
 
 // ---------------------------------------------------------------------------
 // Namespaced storage keys (#58)
@@ -106,6 +107,7 @@ pub struct ZKAttestation;
 impl ZKAttestationContract {
     pub fn register_circuit(
         env: Env,
+        admin_address: Address,
         circuit_id: Symbol,
         name: Bytes,
         description: Bytes,
@@ -115,7 +117,9 @@ impl ZKAttestationContract {
         circuit_type: CircuitType,
         supported_attributes: Vec<Symbol>,
     ) -> Result<(), ZKAttestationError> {
-        let creator = env.current_contract_address();
+        admin_address.require_auth();
+        admin::only_admin(&env, &admin_address)
+            .map_err(|_| ZKAttestationError::Unauthorized)?;
 
         if env
             .storage()
@@ -485,8 +489,10 @@ mod tests {
 
     fn register_test_circuit(env: &Env) -> Symbol {
         let circuit_id = Symbol::new(env, "test_circuit");
+        let admin = env.current_contract_address();
         ZKAttestation::register_circuit(
             env.clone(),
+            admin,
             circuit_id.clone(),
             Bytes::from_slice(env, b"Test Circuit"),
             Bytes::from_slice(env, b"Test Description"),
@@ -506,9 +512,11 @@ mod tests {
     fn test_circuit_registered_event_emitted() {
         let env = setup_env();
         let circuit_id = Symbol::new(&env, "test_circuit");
+        let admin = env.current_contract_address();
 
         ZKAttestation::register_circuit(
             env.clone(),
+            admin,
             circuit_id,
             Bytes::from_slice(&env, b"Test Circuit"),
             Bytes::from_slice(&env, b"Test Description"),


### PR DESCRIPTION
## Summary

Implements 4 issues assigned to @Penielka:

### #42 - Admin Role & Access Control System
- Created shared admin module (`src/admin.rs`) with `init`, `transfer_admin`, `renounce_admin`, `only_admin` guard
- Emits `AdminTransferred` and `AdminRenounced` events
- Integrated into `credential_issuer.rs` (`authorize_issuer`/`deauthorize_issuer`) and `zk_attestation.rs` (`register_circuit`)
- Comprehensive unit tests

### #43 - Credential Expiration & Auto-Revocation
- Added `revoke_expired_credentials` batch cleanup function with configurable batch size
- Added `renew_credential` method for credential renewal with new expiration
- Unit tests for expiration and renewal flows

### #44 - Credential Status List (Bitstring)
- Implemented W3C-compliant `BitstringStatusList` contract (`src/status_list.rs`)
- `create_status_list`, `set_status`, `get_status`, `batch_get_status`, `get_encoded_list`, `deactivate_status_list`
- Gas-efficient bit operations
- Unit tests

### #40 - Business Verification Example
- Enhanced `examples/business-verification.ts` with tax ID and multi-jurisdictional compliance
- Added `npm run example:business` script

### Supporting changes
- Updated `src/lib.rs` with module declarations and exports

Closes #40, closes #42, closes #43, closes #44