### PR TITLE
fix: resolve issues #21, #22, #23, #24 assigned to solomon35-stack

### DIFF
--- a/sdk/src/__tests__/credentialClient.test.ts
+++ b/sdk/src/__tests__/credentialClient.test.ts
@@ -1,0 +1,405 @@
+import { CredentialClient } from '../credentialClient';
+import { StellarIdentityConfig } from '../types';
+
+// ── Mock stellar-sdk ─────────────────────────────────────────────────────────
+const mockToScAddress = jest.fn().mockReturnValue(Buffer.alloc(32));
+
+jest.mock('stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      simulateTransaction: jest.fn(),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    })),
+    Api: {
+      isSimulationError: jest.fn().mockReturnValue(false),
+      SimulateTransactionSuccessResponse: class {},
+      SimulateTransactionErrorResponse: class {},
+    },
+  },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn().mockReturnValue({}),
+  })),
+  Keypair: {
+    random: jest.fn().mockReturnValue({
+      publicKey: jest.fn().mockReturnValue('GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5'),
+      sign: jest.fn(),
+    }),
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  Networks: {
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+    TESTNET: 'Test SDF Network ; September 2015',
+    FUTURENET: 'Test SDF Future Network ; October 2022',
+  },
+  Address: jest.fn().mockImplementation(() => ({
+    toScAddress: mockToScAddress,
+  })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn(),
+  xdr: {
+    ScVal: {
+      scvAddress: jest.fn().mockReturnValue({}),
+      scvVec: jest.fn().mockReturnValue({}),
+      scvVoid: jest.fn().mockReturnValue({}),
+      scvMap: jest.fn().mockReturnValue({}),
+    },
+  },
+  Transaction: class {},
+}));
+
+const stellarSdk = require('stellar-sdk');
+
+jest.mock('../cacheManager', () => ({
+  CacheManager: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    invalidate: jest.fn(),
+  })),
+  DataType: {
+    CREDENTIAL_STATUS: 'credential_status',
+  },
+}));
+
+jest.mock('../compression', () => ({
+  compressPayload: jest.fn().mockResolvedValue('compressed_data'),
+  decompressPayload: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../dataMinimization', () => ({
+  DataMinimizationEngine: jest.fn().mockImplementation(() => ({
+    applyDisclosurePolicy: jest.fn((cred: any) => cred),
+  })),
+}));
+
+const validTestnetConfig: StellarIdentityConfig = {
+  network: 'testnet',
+  contracts: {
+    didRegistry: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822a',
+    credentialIssuer: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822b',
+    reputationScore: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822c',
+    zkAttestation: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822d',
+    complianceFilter: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822e',
+  },
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+};
+
+const VALID_ISSUER = 'GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5';
+const VALID_SUBJECT = 'GB5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5';
+
+function buildMockCredentialRaw(overrides: Record<string, unknown> = {}) {
+  return {
+    id: new TextEncoder().encode('cred-123'),
+    issuer: new TextEncoder().encode(VALID_ISSUER),
+    subject: new TextEncoder().encode(VALID_SUBJECT),
+    type: [new TextEncoder().encode('KYCVerification')],
+    credential_data: new TextEncoder().encode('{"name":"Test"}'),
+    issuance_date: 1700000000n,
+    expiration_date: undefined,
+    revocation: undefined,
+    proof: undefined,
+    ...overrides,
+  };
+}
+
+describe('CredentialClient', () => {
+  let client: CredentialClient;
+  let mockIssuerKeypair: any;
+  let mockServer: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServer = {
+      simulateTransaction: jest.fn().mockResolvedValue({
+        result: { retval: {} },
+      }),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    };
+    stellarSdk.SorobanRpc.Server.mockReturnValue(mockServer);
+    stellarSdk.Address.mockImplementation(() => ({
+      toScAddress: mockToScAddress,
+    }));
+    stellarSdk.Address.fromString = jest.fn();
+    stellarSdk.scValToNative.mockReturnValue(null);
+    stellarSdk.SorobanRpc.Api.isSimulationError.mockReturnValue(false);
+
+    // Re-apply Contract mock factory
+    const { Contract, Keypair } = require('stellar-sdk');
+    Contract.mockImplementation(() => ({
+      call: jest.fn().mockReturnValue({}),
+    }));
+    Keypair.random.mockReturnValue({
+      publicKey: jest.fn().mockReturnValue(VALID_ISSUER),
+      sign: jest.fn().mockReturnValue(Buffer.from([0x01, 0x02, 0x03])),
+    });
+
+    client = new CredentialClient(validTestnetConfig);
+    mockIssuerKeypair = {
+      publicKey: jest.fn().mockReturnValue(VALID_ISSUER),
+      sign: jest.fn().mockReturnValue(Buffer.from([0x01, 0x02, 0x03])),
+    };
+  });
+
+  describe('issueCredential', () => {
+    it('should issue a credential and return credential ID', async () => {
+      mockServer.getAccount.mockResolvedValue({
+        accountId: () => VALID_ISSUER,
+        sequenceNumber: () => '12345',
+        incrementSequenceNumber: () => {},
+      });
+      mockServer.prepareTransaction.mockResolvedValue({ sign: jest.fn() });
+      mockServer.sendTransaction.mockResolvedValue({ status: 'SUCCESS', hash: 'abc123' });
+
+      const credentialId = await client.issueCredential(mockIssuerKeypair, {
+        subject: VALID_SUBJECT,
+        credentialType: ['KYCVerification', 'VerifiableCredential'],
+        credentialData: { name: 'Test User' },
+        proof: 'mockproof',
+        expirationDate: Date.now() + 365 * 24 * 60 * 60 * 1000,
+      });
+
+      expect(credentialId).toMatch(/^cred-/);
+    });
+
+    it('should reject empty subject', async () => {
+      await expect(client.issueCredential(mockIssuerKeypair, {
+        subject: '',
+        credentialType: ['Test'],
+        credentialData: {},
+        proof: 'proof',
+      })).rejects.toThrow();
+    });
+
+    it('should reject empty credential types', async () => {
+      await expect(client.issueCredential(mockIssuerKeypair, {
+        subject: VALID_SUBJECT,
+        credentialType: [],
+        credentialData: {},
+        proof: 'proof',
+      })).rejects.toThrow();
+    });
+
+    it('should reject null credential data', async () => {
+      await expect(client.issueCredential(mockIssuerKeypair, {
+        subject: VALID_SUBJECT,
+        credentialType: ['KYC'],
+        credentialData: null as any,
+        proof: 'proof',
+      })).rejects.toThrow();
+    });
+  });
+
+  describe('verifyCredential', () => {
+    it('should verify a credential and return verification result', async () => {
+      // verifyCredential calls getCredential -> verify_credential -> get_credential_status
+      // Each is a simulateRead call
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return buildMockCredentialRaw(); // getCredential
+        if (callIndex === 2) return true; // verify_credential
+        return 'active'; // get_credential_status
+      });
+
+      const result = await client.verifyCredential('cred-123');
+      expect(result.valid).toBe(true);
+      expect(result.revoked).toBe(false);
+    });
+  });
+
+  describe('revokeCredential', () => {
+    it('should revoke a credential', async () => {
+      mockServer.getAccount.mockResolvedValue({
+        accountId: () => VALID_ISSUER,
+        sequenceNumber: () => '12345',
+        incrementSequenceNumber: () => {},
+      });
+      mockServer.prepareTransaction.mockResolvedValue({ sign: jest.fn() });
+      mockServer.sendTransaction.mockResolvedValue({ status: 'SUCCESS' });
+
+      await expect(
+        client.revokeCredential(mockIssuerKeypair, 'cred-123', 'User requested')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getCredential', () => {
+    it('should retrieve a credential by ID', async () => {
+      stellarSdk.scValToNative.mockReturnValue(buildMockCredentialRaw());
+
+      const credential = await client.getCredential('cred-123');
+      expect(credential.id).toBe('cred-123');
+      expect(credential.issuer).toBe(VALID_ISSUER);
+    });
+  });
+
+  describe('getSubjectCredentials', () => {
+    it('should return credentials for a subject', async () => {
+      stellarSdk.scValToNative.mockReturnValue([
+        new TextEncoder().encode('cred-1'),
+        new TextEncoder().encode('cred-2'),
+      ]);
+
+      const creds = await client.getSubjectCredentials(VALID_SUBJECT);
+      expect(creds).toEqual(['cred-1', 'cred-2']);
+    });
+  });
+
+  describe('getIssuerCredentials', () => {
+    it('should return credentials issued by an issuer', async () => {
+      stellarSdk.scValToNative.mockReturnValue([
+        new TextEncoder().encode('cred-1'),
+      ]);
+
+      const creds = await client.getIssuerCredentials(VALID_ISSUER);
+      expect(creds).toEqual(['cred-1']);
+    });
+  });
+
+  describe('getCredentialStatus', () => {
+    it('should return credential status string', async () => {
+      stellarSdk.scValToNative.mockReturnValue(new TextEncoder().encode('active'));
+
+      const status = await client.getCredentialStatus('cred-123');
+      expect(status).toBe('active');
+    });
+  });
+
+  describe('getRevocationReason', () => {
+    it('should return null when credential is not revoked', async () => {
+      stellarSdk.scValToNative.mockReturnValue(null);
+
+      const reason = await client.getRevocationReason('cred-123');
+      expect(reason).toBeNull();
+    });
+
+    it('should return revocation reason when revoked', async () => {
+      stellarSdk.scValToNative.mockReturnValue(new TextEncoder().encode('Key compromised'));
+
+      const reason = await client.getRevocationReason('cred-123');
+      expect(reason).toBe('Key compromised');
+    });
+  });
+
+  describe('createPresentation', () => {
+    it('should create a verifiable presentation', async () => {
+      const credentials = [{
+        id: 'cred-1', issuer: VALID_ISSUER, subject: VALID_SUBJECT,
+        type: ['KYCVerification'], credentialData: {}, issuanceDate: Date.now(),
+      }];
+
+      const presentation = await client.createPresentation(
+        credentials,
+        mockIssuerKeypair,
+        'example.com',
+        'challenge123',
+      );
+
+      expect(presentation.type).toContain('VerifiablePresentation');
+      expect(presentation.verifiableCredential).toHaveLength(1);
+    });
+  });
+
+  describe('verifyPresentation', () => {
+    it('should verify a valid presentation', async () => {
+      // verifyPresentation calls verifyCredential for each cred
+      // Each verifyCredential does: getCredential → verify → getStatus = 3 calls
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return buildMockCredentialRaw({ id: new TextEncoder().encode('cred-1') });
+        if (callIndex === 2) return true;
+        return 'active';
+      });
+
+      const result = await client.verifyPresentation({
+        holder: VALID_ISSUER,
+        verifiableCredential: [{
+          id: 'cred-1', issuer: VALID_ISSUER, subject: VALID_SUBJECT,
+          type: ['KYCVerification'], credentialData: {}, issuanceDate: Date.now(),
+        }],
+        proof: { type: 'Ed25519Signature2018', jws: 'sig123' },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for presentation with missing proof', async () => {
+      const result = await client.verifyPresentation({
+        holder: VALID_ISSUER,
+        verifiableCredential: [],
+        proof: undefined,
+      });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('issueKYCCredential', () => {
+    it('should issue a KYC credential', async () => {
+      mockServer.getAccount.mockResolvedValue({
+        accountId: () => VALID_ISSUER,
+        sequenceNumber: () => '12345',
+        incrementSequenceNumber: () => {},
+      });
+      mockServer.prepareTransaction.mockResolvedValue({ sign: jest.fn() });
+      mockServer.sendTransaction.mockResolvedValue({ status: 'SUCCESS', hash: 'abc123' });
+
+      const credentialId = await client.issueKYCCredential(
+        mockIssuerKeypair,
+        VALID_SUBJECT,
+        {
+          firstName: 'John', lastName: 'Doe', dateOfBirth: '1990-01-01',
+          nationality: 'US', documentType: 'Passport',
+          documentNumber: '123456789', expiryDate: '2030-01-01',
+        },
+      );
+
+      expect(credentialId).toMatch(/^cred-/);
+    });
+  });
+
+  describe('issueEducationCredential', () => {
+    it('should issue an education credential', async () => {
+      mockServer.getAccount.mockResolvedValue({
+        accountId: () => VALID_ISSUER,
+        sequenceNumber: () => '12345',
+        incrementSequenceNumber: () => {},
+      });
+      mockServer.prepareTransaction.mockResolvedValue({ sign: jest.fn() });
+      mockServer.sendTransaction.mockResolvedValue({ status: 'SUCCESS', hash: 'abc123' });
+
+      const credentialId = await client.issueEducationCredential(
+        mockIssuerKeypair,
+        VALID_SUBJECT,
+        {
+          degree: 'Bachelor of Science', institution: 'University of Stellar',
+          fieldOfStudy: 'Computer Science', graduationDate: '2023-06-01', gpa: 3.8,
+        },
+      );
+
+      expect(credentialId).toMatch(/^cred-/);
+    });
+  });
+
+  describe('batchVerifyCredentials', () => {
+    it('should verify multiple credentials in parallel', async () => {
+      // Always return a valid credential raw regardless of call order
+      // This avoids fragility from Promise.all interleaving
+      stellarSdk.scValToNative.mockImplementation(() =>
+        buildMockCredentialRaw({ id: new TextEncoder().encode('cred-x') })
+      );
+
+      const results = await client.batchVerifyCredentials(['cred-1', 'cred-2']);
+      expect(results).toHaveLength(2);
+    });
+  });
+});

--- a/sdk/src/__tests__/didClient.test.ts
+++ b/sdk/src/__tests__/didClient.test.ts
@@ -1,0 +1,326 @@
+import { DIDClient } from '../didClient';
+import { StellarIdentityConfig } from '../types';
+
+// ── Mock stellar-sdk ─────────────────────────────────────────────────────────
+const mockToScAddress = jest.fn().mockReturnValue(Buffer.alloc(32));
+
+jest.mock('stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      simulateTransaction: jest.fn(),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    })),
+    Api: {
+      isSimulationError: jest.fn().mockReturnValue(false),
+      SimulateTransactionSuccessResponse: class {},
+      SimulateTransactionErrorResponse: class {},
+      GetTransactionStatus: {
+        SUCCESS: 'SUCCESS',
+        FAILED: 'FAILED',
+        NOT_FOUND: 'NOT_FOUND',
+      },
+    },
+  },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn().mockReturnValue({}),
+  })),
+  Keypair: {
+    random: jest.fn().mockReturnValue({
+      publicKey: jest.fn().mockReturnValue('GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5'),
+      sign: jest.fn(),
+    }),
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  Networks: {
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+    TESTNET: 'Test SDF Network ; September 2015',
+    FUTURENET: 'Test SDF Future Network ; October 2022',
+  },
+  Address: jest.fn().mockImplementation(() => ({
+    toScAddress: mockToScAddress,
+  })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn(),
+  xdr: {
+    ScVal: {
+      scvAddress: jest.fn().mockReturnValue({}),
+      scvVec: jest.fn().mockReturnValue({}),
+      scvVoid: jest.fn().mockReturnValue({}),
+      scvMap: jest.fn().mockReturnValue({}),
+    },
+    Operation: {} as any,
+  },
+  Transaction: class {},
+}));
+
+// Import mocks after jest.mock
+const stellarSdk = require('stellar-sdk');
+
+jest.mock('../cacheManager', () => ({
+  CacheManager: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    invalidate: jest.fn(),
+  })),
+  DataType: {
+    DID_DOCUMENT: 'did_document',
+  },
+}));
+
+const validTestnetConfig: StellarIdentityConfig = {
+  network: 'testnet',
+  contracts: {
+    didRegistry: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822a',
+    credentialIssuer: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822b',
+    reputationScore: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822c',
+    zkAttestation: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822d',
+    complianceFilter: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822e',
+  },
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+};
+
+const VALID_ADDRESS = 'GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5';
+const VALID_DID = `did:stellar:${VALID_ADDRESS}`;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockSimSuccess(retval?: any) {
+  stellarSdk.SorobanRpc.Api.isSimulationError.mockReturnValue(false);
+}
+
+function mockWriteSuccess(hash = 'abc123', ledger = 1000) {
+  return {
+    getAccount: jest.fn().mockResolvedValue({
+      accountId: () => VALID_ADDRESS,
+      sequenceNumber: () => '12345',
+      incrementSequenceNumber: () => {},
+    }),
+    prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+    sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash }),
+    getTransaction: jest.fn().mockResolvedValue({ status: 'SUCCESS', ledger }),
+  };
+}
+
+describe('DIDClient', () => {
+  let client: DIDClient;
+  let mockKeypair: any;
+  let mockServer: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-init the SorobanRpc.Server mock to return fresh mockServer each time
+    mockServer = {
+      simulateTransaction: jest.fn().mockResolvedValue({
+        result: { retval: {} },
+      }),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    };
+    stellarSdk.SorobanRpc.Server.mockReturnValue(mockServer);
+
+    // Re-apply Address mock factory (clearAllMocks preserves factory)
+    stellarSdk.Address.mockImplementation(() => ({
+      toScAddress: mockToScAddress,
+    }));
+    stellarSdk.Address.fromString = jest.fn();
+
+    // Always return null by default for scValToNative
+    stellarSdk.scValToNative.mockReturnValue(null);
+    stellarSdk.SorobanRpc.Api.isSimulationError.mockReturnValue(false);
+
+    // Re-apply Contract mock (in case clearAllMocks reset the factory's return inline mocks)
+    const { Contract } = require('stellar-sdk');
+    Contract.mockImplementation(() => ({
+      call: jest.fn().mockReturnValue({}),
+    }));
+
+    client = new DIDClient(validTestnetConfig);
+    mockKeypair = {
+      publicKey: jest.fn().mockReturnValue(VALID_ADDRESS),
+      sign: jest.fn(),
+    };
+  });
+
+  describe('constructor', () => {
+    it('should throw ConfigurationError when didRegistry is missing', () => {
+      expect(() => {
+        new DIDClient({
+          ...validTestnetConfig,
+          contracts: { ...validTestnetConfig.contracts, didRegistry: '' as any },
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('generateDID', () => {
+    it('should generate a valid did:stellar DID', () => {
+      const did = client.generateDID(VALID_ADDRESS);
+      expect(did).toBe(VALID_DID);
+    });
+
+    it('should generate DID with suffix', () => {
+      const did = client.generateDID(VALID_ADDRESS, 'v1');
+      expect(did).toBe(`${VALID_DID}:v1`);
+    });
+  });
+
+  describe('validateDIDFormat', () => {
+    it('should return true for valid DID', () => {
+      expect(client.validateDIDFormat(VALID_DID)).toBe(true);
+    });
+
+    it('should return false for non-stellar DID', () => {
+      expect(client.validateDIDFormat('did:eth:0x123')).toBe(false);
+    });
+
+    it('should return false for invalid format', () => {
+      expect(client.validateDIDFormat('not-a-did')).toBe(false);
+    });
+  });
+
+  describe('extractStellarAddress', () => {
+    it('should extract address from DID', () => {
+      const address = client.extractStellarAddress(VALID_DID);
+      expect(address).toBe(VALID_ADDRESS);
+    });
+  });
+
+  describe('createDID', () => {
+    it('should create a DID via contract call', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const did = await client.createDID(mockKeypair, {
+        verificationMethods: [{
+          id: '#key-1', type: 'Ed25519VerificationKey2018',
+          controller: VALID_ADDRESS, publicKey: 'deadbeef',
+        }],
+        services: [{
+          id: '#hub', type: 'IdentityHub',
+          endpoint: 'https://hub.example.com',
+        }],
+      });
+
+      expect(did).toBe(VALID_DID);
+    });
+  });
+
+  describe('resolveDID', () => {
+    it('should resolve a DID document', async () => {
+      mockSimSuccess();
+      stellarSdk.scValToNative.mockReturnValue({
+        id: new TextEncoder().encode(VALID_DID),
+        controller: new TextEncoder().encode(VALID_ADDRESS),
+        verification_method: [],
+        authentication: [],
+        service: [],
+        created: 1700000000n,
+        updated: 1700000000n,
+      });
+
+      const result = await client.resolveDID(VALID_DID);
+      expect(result.didDocument.id).toBe(VALID_DID);
+    });
+
+    it('should reject invalid DID format', async () => {
+      await expect(client.resolveDID('invalid')).rejects.toThrow();
+    });
+  });
+
+  describe('resolveDIDBatch', () => {
+    it('should resolve multiple DIDs', async () => {
+      mockSimSuccess();
+      stellarSdk.scValToNative.mockReturnValue({
+        id: new TextEncoder().encode(VALID_DID),
+        controller: new TextEncoder().encode(VALID_ADDRESS),
+        verification_method: [],
+        authentication: [],
+        service: [],
+        created: 1700000000n,
+        updated: 1700000000n,
+      });
+
+      const results = await client.resolveDIDBatch([VALID_DID, `did:stellar:GB5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5`]);
+      expect(results).toHaveLength(2);
+      expect(results[0].error).toBeNull();
+      expect(results[0].result?.didDocument.id).toBe(VALID_DID);
+    });
+  });
+
+  describe('updateDID', () => {
+    it('should update DID verification methods and services', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const result = await client.updateDID(
+        mockKeypair,
+        [{ id: '#key-2', type: 'Ed25519VerificationKey2018', controller: VALID_ADDRESS, publicKey: 'cafebabe' }],
+        [{ id: '#svc', type: 'CredentialRepository', endpoint: 'https://cred.example.com' }],
+      );
+
+      expect(result.status).toBe('SUCCESS');
+    });
+  });
+
+  describe('deactivateDID', () => {
+    it('should deactivate a DID', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const result = await client.deactivateDID(mockKeypair);
+      expect(result.status).toBe('SUCCESS');
+    });
+  });
+
+  describe('didExists', () => {
+    it('should return true when DID exists', async () => {
+      mockSimSuccess();
+      stellarSdk.scValToNative.mockReturnValue(true);
+
+      const exists = await client.didExists(VALID_DID);
+      expect(exists).toBe(true);
+    });
+  });
+
+  describe('getControllerDID', () => {
+    it('should return null when no DID is registered', async () => {
+      mockSimSuccess();
+      stellarSdk.scValToNative.mockReturnValue(null);
+
+      const did = await client.getControllerDID(VALID_ADDRESS);
+      expect(did).toBeNull();
+    });
+
+    it('should return DID string when registered', async () => {
+      mockSimSuccess();
+      stellarSdk.scValToNative.mockReturnValue(new TextEncoder().encode(VALID_DID));
+
+      const did = await client.getControllerDID(VALID_ADDRESS);
+      expect(did).toBe(VALID_DID);
+    });
+  });
+
+  describe('addAuthentication', () => {
+    it('should add an authentication method', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const result = await client.addAuthentication(mockKeypair, '#auth-1');
+      expect(result.status).toBe('SUCCESS');
+    });
+  });
+
+  describe('removeAuthentication', () => {
+    it('should remove an authentication method', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const result = await client.removeAuthentication(mockKeypair, '#auth-1');
+      expect(result.status).toBe('SUCCESS');
+    });
+  });
+});

--- a/sdk/src/__tests__/reputation.test.ts
+++ b/sdk/src/__tests__/reputation.test.ts
@@ -1,0 +1,413 @@
+import { ReputationClient } from '../reputation';
+import { StellarIdentityConfig } from '../types';
+
+// ── Mock stellar-sdk ─────────────────────────────────────────────────────────
+const mockToScAddress = jest.fn().mockReturnValue(Buffer.alloc(32));
+
+jest.mock('stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      simulateTransaction: jest.fn(),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    })),
+    Api: {
+      isSimulationError: jest.fn().mockReturnValue(false),
+      SimulateTransactionSuccessResponse: class {},
+      SimulateTransactionErrorResponse: class {},
+    },
+  },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn().mockReturnValue({}),
+  })),
+  Keypair: {
+    random: jest.fn().mockReturnValue({
+      publicKey: jest.fn().mockReturnValue('GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5'),
+      sign: jest.fn(),
+    }),
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({
+      hash: () => ({ toString: () => 'abchash' }),
+    }),
+  })),
+  Networks: {
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+    TESTNET: 'Test SDF Network ; September 2015',
+    FUTURENET: 'Test SDF Future Network ; October 2022',
+  },
+  Address: jest.fn().mockImplementation(() => ({
+    toScAddress: mockToScAddress,
+  })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn(),
+  xdr: {
+    ScVal: {
+      scvAddress: jest.fn().mockReturnValue({}),
+      scvVec: jest.fn().mockReturnValue({}),
+      scvVoid: jest.fn().mockReturnValue({}),
+      scvMap: jest.fn().mockReturnValue({}),
+    },
+    ScMapEntry: jest.fn().mockImplementation((entry: any) => entry),
+  },
+  Transaction: class {},
+}));
+
+const stellarSdk = require('stellar-sdk');
+
+jest.mock('crypto-js', () => ({
+  SHA256: jest.fn().mockReturnValue({ toString: () => 'mockcommitmenthash' }),
+}));
+
+const validTestnetConfig: StellarIdentityConfig = {
+  network: 'testnet',
+  contracts: {
+    didRegistry: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822a',
+    credentialIssuer: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822b',
+    reputationScore: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822c',
+    zkAttestation: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822d',
+    complianceFilter: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822e',
+  },
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+};
+
+const VALID_ADDRESS = 'GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5';
+
+const mockReputationData: Record<string, unknown> = {
+  did: VALID_ADDRESS,
+  score: 7500n,
+  transaction_count: 100n,
+  successful_transactions: 95n,
+  credential_count: 5n,
+  valid_credentials: 5n,
+  last_updated: 1700000000n,
+  created_at: 1690000000n,
+  reputation_factors: {
+    transaction_volume: 80n,
+    transaction_consistency: 90n,
+    credential_count: 70n,
+    credential_diversity: 75n,
+    account_age: 60n,
+    dispute_history: 95n,
+  },
+  transaction_volume_sum: 100000n,
+  counterparty_diversity: 20n,
+  fee_consistency: 85n,
+  contract_interactions: 50n,
+  verified_kyc: 2n,
+  employment_credentials: 1n,
+  academic_credentials: 1n,
+  self_claimed_credentials: 0n,
+  sanctions_matches: 0n,
+  credential_revocations: 0n,
+  disputes: 0n,
+};
+
+function mockWriteFlow(mockServer: any) {
+  mockServer.getAccount.mockResolvedValue({
+    accountId: () => VALID_ADDRESS,
+    sequenceNumber: () => '12345',
+    incrementSequenceNumber: () => {},
+  });
+  mockServer.prepareTransaction.mockResolvedValue({ sign: jest.fn() });
+  mockServer.sendTransaction.mockResolvedValue({ status: 'PENDING', hash: 'abc' });
+  // getTransaction returns SUCCESS with resultMetaXdr so invokeWrite returns simulated retval
+  mockServer.getTransaction.mockResolvedValue({
+    status: 'SUCCESS',
+    ledger: 1000,
+    resultMetaXdr: {},
+  });
+}
+
+describe('ReputationClient', () => {
+  let client: ReputationClient;
+  let mockKeypair: any;
+  let mockServer: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServer = {
+      simulateTransaction: jest.fn().mockResolvedValue({
+        result: { retval: {} },
+      }),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    };
+    stellarSdk.SorobanRpc.Server.mockReturnValue(mockServer);
+    stellarSdk.Address.mockImplementation(() => ({
+      toScAddress: mockToScAddress,
+    }));
+    stellarSdk.Address.fromString = jest.fn();
+    stellarSdk.scValToNative.mockReturnValue(null);
+    stellarSdk.SorobanRpc.Api.isSimulationError.mockReturnValue(false);
+
+    // Re-apply Contract mock factory
+    const { Contract } = require('stellar-sdk');
+    Contract.mockImplementation(() => ({
+      call: jest.fn().mockReturnValue({}),
+    }));
+
+    client = new ReputationClient(validTestnetConfig);
+    mockKeypair = {
+      publicKey: jest.fn().mockReturnValue(VALID_ADDRESS),
+      sign: jest.fn(),
+    };
+  });
+
+  describe('initializeReputation', () => {
+    it('should initialize reputation for a new address', async () => {
+      mockWriteFlow(mockServer);
+      stellarSdk.scValToNative.mockReturnValue(mockReputationData);
+
+      const result = await client.initializeReputation(mockKeypair);
+      expect(result.did).toBe(VALID_ADDRESS);
+      expect(result.score).toBe(750.0);
+    });
+  });
+
+  describe('updateTransactionReputation', () => {
+    it('should update reputation after a successful transaction', async () => {
+      mockWriteFlow(mockServer);
+      stellarSdk.scValToNative.mockReturnValue(7600n);
+
+      const score = await client.updateTransactionReputation(mockKeypair, VALID_ADDRESS, true, 5000);
+      expect(typeof score).toBe('number');
+    });
+  });
+
+  describe('updateCredentialReputation', () => {
+    it('should update reputation after credential validation', async () => {
+      mockWriteFlow(mockServer);
+      stellarSdk.scValToNative.mockReturnValue(7700n);
+
+      const score = await client.updateCredentialReputation(mockKeypair, VALID_ADDRESS, true, 'KYCVerification');
+      expect(typeof score).toBe('number');
+    });
+  });
+
+  describe('calculateReputation', () => {
+    it('should calculate reputation score', async () => {
+      stellarSdk.scValToNative.mockReturnValue(8000n);
+
+      const score = await client.calculateReputation(VALID_ADDRESS);
+      expect(score).toBe(800.0);
+    });
+  });
+
+  describe('getReputationScore', () => {
+    it('should return a reputation breakdown with score and tier', async () => {
+      // getReputationData + getReputationPercentile
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return mockReputationData;
+        return 85;
+      });
+
+      const breakdown = await client.getReputationScore(VALID_ADDRESS);
+      expect(breakdown.score).toBe(750.0);
+      expect(breakdown.percentile).toBe(85);
+      expect(breakdown.tier).toBe('Strong');
+    });
+  });
+
+  describe('getReputationScoreValue', () => {
+    it('should return numeric score only', async () => {
+      stellarSdk.scValToNative.mockReturnValue(7500n);
+
+      const score = await client.getReputationScoreValue(VALID_ADDRESS);
+      expect(score).toBe(750.0);
+    });
+  });
+
+  describe('getReputationData', () => {
+    it('should return raw reputation data', async () => {
+      stellarSdk.scValToNative.mockReturnValue(mockReputationData);
+
+      const data = await client.getReputationData(VALID_ADDRESS);
+      expect(data.did).toBe(VALID_ADDRESS);
+      expect(data.transactionCount).toBe(100);
+      expect(data.credentialCount).toBe(5);
+    });
+  });
+
+  describe('getReputationHistory', () => {
+    it('should return reputation history points', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      stellarSdk.scValToNative.mockReturnValue([
+        { timestamp: BigInt(now - 10000), score: 7000n, event_type: 'transaction' },
+        { timestamp: BigInt(now - 5000), score: 7300n, event_type: 'credential' },
+      ]);
+
+      const history = await client.getReputationHistory(VALID_ADDRESS, '180d');
+      expect(history).toHaveLength(2);
+      expect(history[0].score).toBe(700.0);
+    });
+  });
+
+  describe('attestTrust', () => {
+    it('should attest trust for another DID', async () => {
+      mockWriteFlow(mockServer);
+      stellarSdk.scValToNative.mockReturnValue({
+        truster: VALID_ADDRESS,
+        subject: 'GB5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5',
+        weight: 800n,
+        reason: new TextEncoder().encode('Trusted partner'),
+        timestamp: 1700000000n,
+      });
+
+      const edge = await client.attestTrust(mockKeypair, 'GB5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5', 800, 'Trusted partner');
+      expect(edge.truster).toBe(VALID_ADDRESS);
+      expect(edge.weight).toBe(800);
+    });
+  });
+
+  describe('getTrustGraph', () => {
+    it('should return trust edges for a DID', async () => {
+      stellarSdk.scValToNative.mockReturnValue([{
+        truster: 'GA...', subject: 'GB...', weight: 500n,
+        reason: new TextEncoder().encode('Good standing'), timestamp: 1700000000n,
+      }]);
+
+      const edges = await client.getTrustGraph(VALID_ADDRESS, 2);
+      expect(edges).toHaveLength(1);
+    });
+  });
+
+  describe('compareReputation', () => {
+    it('should compare two reputation profiles', async () => {
+      // 4 calls: data A, percentile A, data B, percentile B
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return mockReputationData;
+        if (callIndex === 2) return 85;
+        if (callIndex === 3) return { ...mockReputationData, score: 5000n };
+        return 50;
+      });
+
+      const comparison = await client.compareReputation(VALID_ADDRESS, 'GB5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5');
+      expect(comparison.winner).toBe('didA');
+      expect(comparison.didA.score).toBe(750.0);
+      expect(comparison.didB.score).toBe(500.0);
+    });
+  });
+
+  describe('getReputationAnalysis', () => {
+    it('should return comprehensive ReputationScoreResult', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return mockReputationData;
+        if (callIndex === 2) return 85;
+        // getReputationHistory
+        return [{ timestamp: BigInt(now - 5000), score: 7000n, event_type: 'transaction' }];
+      });
+
+      const analysis = await client.getReputationAnalysis(VALID_ADDRESS);
+      expect(analysis.score).toBe(750.0);
+      expect(analysis.percentile).toBe(85);
+      expect(analysis.history).toHaveLength(1);
+    });
+  });
+
+  describe('getReputationTier', () => {
+    it('should return Prime tier for score >= 900', () => {
+      expect(client.getReputationTier(920).tier).toBe('Prime');
+    });
+
+    it('should return Strong tier for score >= 750', () => {
+      expect(client.getReputationTier(800).tier).toBe('Strong');
+    });
+
+    it('should return Established tier for score >= 550', () => {
+      expect(client.getReputationTier(600).tier).toBe('Established');
+    });
+
+    it('should return Emerging tier for score >= 300', () => {
+      expect(client.getReputationTier(400).tier).toBe('Emerging');
+    });
+
+    it('should return Seedling tier for score < 300', () => {
+      expect(client.getReputationTier(150).tier).toBe('Seedling');
+    });
+  });
+
+  describe('meetsReputationThreshold', () => {
+    it('should check if DID meets a threshold', async () => {
+      stellarSdk.scValToNative.mockReturnValue(true);
+
+      const meets = await client.meetsReputationThreshold(VALID_ADDRESS, 500);
+      expect(meets).toBe(true);
+    });
+  });
+
+  describe('getReputationFactors', () => {
+    it('should return reputation factor values', async () => {
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return mockReputationData;
+        return 85;
+      });
+
+      const factors = await client.getReputationFactors(VALID_ADDRESS);
+      expect(factors.transactionVolume).toBe(80);
+      expect(factors.transactionConsistency).toBe(90);
+    });
+  });
+
+  describe('getReputationTierProof', () => {
+    it('should generate a tier proof with commitment', async () => {
+      let callIndex = 0;
+      stellarSdk.scValToNative.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return mockReputationData;
+        return 85;
+      });
+
+      const proof = await client.getReputationTierProof(VALID_ADDRESS);
+      expect(proof.tier).toBe('Strong');
+      expect(proof.commitment).toBe('mockcommitmenthash');
+    });
+  });
+
+  describe('calculateReputationTrend', () => {
+    it('should detect upward trend', () => {
+      const trend = client.calculateReputationTrend([500, 520, 540, 560, 580, 600, 620, 640, 660, 700, 780]);
+      expect(trend.trend).toBe('up');
+    });
+
+    it('should detect downward trend', () => {
+      const trend = client.calculateReputationTrend([800, 780, 760, 740, 720, 700, 680, 660, 640, 620, 580]);
+      expect(trend.trend).toBe('down');
+    });
+
+    it('should detect stable trend', () => {
+      const trend = client.calculateReputationTrend([500, 502, 501, 500, 503, 501, 502, 500, 501, 500, 502]);
+      expect(trend.trend).toBe('stable');
+    });
+
+    it('should handle short history', () => {
+      const trend = client.calculateReputationTrend([]);
+      expect(trend.trend).toBe('stable');
+    });
+  });
+
+  describe('resetReputation', () => {
+    it('should reset reputation data', async () => {
+      mockWriteFlow(mockServer);
+      stellarSdk.scValToNative.mockReturnValue({ ...mockReputationData, score: 0n });
+
+      const result = await client.resetReputation(mockKeypair);
+      expect(result.score).toBe(0);
+    });
+  });
+});

--- a/sdk/src/didClient.ts
+++ b/sdk/src/didClient.ts
@@ -16,6 +16,7 @@ import {
   Service,
   StellarIdentityConfig,
   CreateDIDOptions,
+  UpdateDIDOptions,
   TransactionOptions,
   DIDResolutionResult,
 } from './types';
@@ -241,17 +242,39 @@ export class DIDClient {
    * Update the verification methods and/or services of an existing DID.
    * Pass `undefined` for a field to leave it unchanged on-chain.
    *
+   * Supports two calling conventions:
+   * 1. `updateDID(keypair, options: UpdateDIDOptions, txOptions?)`
+   * 2. `updateDID(keypair, verificationMethods?, services?, txOptions?)`
+   *
    * @param keypair - The keypair of the DID controller.
-   * @param verificationMethods - Replacement verification methods, or undefined.
-   * @param services - Replacement services, or undefined.
+   * @param optionsOrVMs - Either `UpdateDIDOptions` or verification methods array.
+   * @param servicesOrTx - Services array (when using legacy signature) or txOptions.
    * @param txOptions - Optional transaction parameters.
    */
   async updateDID(
     keypair: Keypair,
-    verificationMethods?: VerificationMethod[],
-    services?: Service[],
+    optionsOrVMs?: UpdateDIDOptions | VerificationMethod[],
+    servicesOrTx?: Service[] | TransactionOptions,
     txOptions?: TransactionOptions,
   ): Promise<TransactionResult> {
+    let verificationMethods: VerificationMethod[] | undefined;
+    let services: Service[] | undefined;
+
+    // Detect calling convention: if first arg is an object with 'verificationMethods' or 'services'
+    if (
+      optionsOrVMs &&
+      typeof optionsOrVMs === 'object' &&
+      !Array.isArray(optionsOrVMs) &&
+      ('verificationMethods' in optionsOrVMs || 'services' in optionsOrVMs)
+    ) {
+      const opts = optionsOrVMs as UpdateDIDOptions;
+      verificationMethods = opts.verificationMethods;
+      services = opts.services;
+      txOptions = servicesOrTx as TransactionOptions | undefined;
+    } else {
+      verificationMethods = optionsOrVMs as VerificationMethod[] | undefined;
+      services = servicesOrTx as Service[] | undefined;
+    }
     const address = keypair.publicKey();
     this.assertValidStellarAddress(address);
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -145,6 +145,7 @@ export type {
   SanctionsList,
   StellarIdentityConfig,
   CreateDIDOptions,
+  UpdateDIDOptions,
   IssueCredentialOptions,
   ZKProofOptions,
   ComplianceCheckOptions,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -232,6 +232,11 @@ export interface CreateDIDOptions {
   services: Service[];
 }
 
+export interface UpdateDIDOptions {
+  verificationMethods?: VerificationMethod[];
+  services?: Service[];
+}
+
 export interface IssueCredentialOptions {
   subject: string;
   credentialType: string[];

--- a/src/compliance_filter.rs
+++ b/src/compliance_filter.rs
@@ -125,6 +125,32 @@ pub struct RiskWeights {
     pub last_updated: u64,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RiskFactor {
+    pub name: Bytes,
+    pub score: u32,
+    pub weight: u32,
+    pub description: Bytes,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RiskAssessment {
+    pub score: u32,
+    pub factors: Vec<RiskFactor>,
+    pub overall: RiskLevel,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -742,6 +768,132 @@ impl ComplianceFilter {
 
     pub fn get_risk_weights(env: Env) -> Option<RiskWeights> {
         env.storage().persistent().get(&CfKey::RiskWeights)
+    }
+
+    /// Set risk assessment weights using a structured `RiskWeights` value.
+    /// Admin-only. Emits `RiskWeightsSet` event.
+    pub fn set_risk_weights(
+        env: Env,
+        admin: Address,
+        weights: RiskWeights,
+    ) -> Result<(), ComplianceFilterError> {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin)?;
+
+        if weights.high_risk_threshold == 0
+            || weights.high_risk_threshold > MAX_RISK_SCORE
+        {
+            return Err(ComplianceFilterError::InvalidRiskScore);
+        }
+
+        let mut stored = weights;
+        stored.last_updated = env.ledger().timestamp();
+
+        Self::persist(&env, &CfKey::RiskWeights, &stored);
+
+        env.events().publish(
+            (Symbol::new(&env, "RiskWeightsSet"),),
+            (
+                stored.sanctions_weight,
+                stored.oracle_weight,
+                stored.high_risk_threshold,
+            ),
+        );
+
+        Ok(())
+    }
+
+    /// Assess risk for an address by combining sanctions screening and oracle
+    /// risk scores using the configured weights.
+    ///
+    /// Returns a `RiskAssessment` with the aggregated score, contributing
+    /// factors, and an overall `RiskLevel`.
+    pub fn assess_risk(
+        env: Env,
+        address: Address,
+    ) -> RiskAssessment {
+        // 1. Sanctions screening
+        let (screening, blocked) = Self::run_screening(&env, &address);
+        let sanction_score: u32 = if blocked { MAX_RISK_SCORE } else { 0 };
+
+        // 2. Oracle score
+        let oracle_score: u32 = env
+            .storage()
+            .persistent()
+            .get::<CfKey, ScreeningResult>(&CfKey::Screening(address.clone()))
+            .map(|stored| {
+                let age = env.ledger().timestamp().saturating_sub(stored.timestamp);
+                if age <= ORACLE_STALENESS_SECS {
+                    stored.risk_score
+                } else {
+                    0
+                }
+            })
+            .unwrap_or(0);
+
+        // 3. Load weights (default to 50/50 if not configured)
+        let weights: RiskWeights = env
+            .storage()
+            .persistent()
+            .get(&CfKey::RiskWeights)
+            .unwrap_or(RiskWeights {
+                sanctions_weight: 50,
+                oracle_weight: 50,
+                high_risk_threshold: HIGH_RISK_THRESHOLD,
+                last_updated: 0,
+            });
+
+        let total_weight = weights.sanctions_weight.saturating_add(weights.oracle_weight);
+        let aggregated_score: u32 = if total_weight == 0 {
+            0
+        } else {
+            (sanction_score
+                .saturating_mul(weights.sanctions_weight)
+                .saturating_add(oracle_score.saturating_mul(weights.oracle_weight)))
+                / total_weight
+        };
+
+        // 4. Build risk factors
+        let mut factors = Vec::new(&env);
+
+        factors.push_back(RiskFactor {
+            name: Bytes::from_slice(&env, b"sanctions"),
+            score: sanction_score,
+            weight: weights.sanctions_weight,
+            description: if blocked {
+                Bytes::from_slice(&env, b"Address found on active sanctions list(s)")
+            } else {
+                Bytes::from_slice(&env, b"No sanctions matches")
+            },
+        });
+
+        factors.push_back(RiskFactor {
+            name: Bytes::from_slice(&env, b"oracle"),
+            score: oracle_score,
+            weight: weights.oracle_weight,
+            description: if oracle_score > 0 {
+                Bytes::from_slice(&env, b"Oracle-assigned risk score")
+            } else {
+                Bytes::from_slice(&env, b"No oracle risk data")
+            },
+        });
+
+        // 5. Determine overall risk level
+        let overall = if aggregated_score >= MAX_RISK_SCORE {
+            RiskLevel::Critical
+        } else if aggregated_score > weights.high_risk_threshold {
+            RiskLevel::High
+        } else if aggregated_score > weights.high_risk_threshold / 2 {
+            RiskLevel::Medium
+        } else {
+            RiskLevel::Low
+        };
+
+        RiskAssessment {
+            score: aggregated_score,
+            factors,
+            overall,
+        }
     }
 
     // ── Regulatory reports & audit trail ──────────────────────────────────────
@@ -1704,5 +1856,173 @@ mod tests {
         let page = ComplianceFilter::get_sanctioned_addresses(env.clone(), 0, 10);
         // `shared` appears in both lists but should only show up once.
         assert_eq!(page.total, 1);
+    }
+
+    // ── Risk assessment ───────────────────────────────────────────────────────
+
+    #[test]
+    fn assess_risk_clean_address_returns_low() {
+        let env = setup_env();
+        bootstrap(&env);
+        let clean = Address::generate(&env);
+
+        let assessment = ComplianceFilter::assess_risk(env.clone(), clean);
+        assert_eq!(assessment.overall, RiskLevel::Low);
+        assert_eq!(assessment.score, 0);
+        assert_eq!(assessment.factors.len(), 2);
+        assert_eq!(assessment.factors.get(0).unwrap().name, Bytes::from_slice(&env, b"sanctions"));
+        assert_eq!(assessment.factors.get(1).unwrap().name, Bytes::from_slice(&env, b"oracle"));
+    }
+
+    #[test]
+    fn assess_risk_sanctioned_address_returns_critical() {
+        let env = setup_env();
+        let admin = bootstrap(&env);
+        let source = create_list(&env, &admin, b"OFAC");
+        let target = Address::generate(&env);
+
+        ComplianceFilter::add_to_sanctions_list(
+            env.clone(),
+            admin,
+            source,
+            target.clone(),
+            Bytes::from_slice(&env, b"fraud"),
+            Bytes::from_slice(&env, b"US"),
+        )
+        .unwrap();
+
+        let assessment = ComplianceFilter::assess_risk(env.clone(), target);
+        assert_eq!(assessment.overall, RiskLevel::Critical);
+        assert_eq!(assessment.score, MAX_RISK_SCORE);
+    }
+
+    #[test]
+    fn assess_risk_with_oracle_score_returns_medium() {
+        let env = setup_env();
+        let admin = bootstrap(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        ComplianceFilter::register_oracle(env.clone(), admin, oracle.clone()).unwrap();
+        ComplianceFilter::update_risk_score(
+            env.clone(),
+            oracle,
+            user.clone(),
+            50,
+            Bytes::from_slice(&env, b"suspicious activity"),
+        )
+        .unwrap();
+
+        let assessment = ComplianceFilter::assess_risk(env.clone(), user);
+        // Default weights: sanctions=50, oracle=50 => (0*50 + 50*50)/100 = 25
+        assert_eq!(assessment.score, 25);
+        assert_eq!(assessment.overall, RiskLevel::Medium);
+    }
+
+    #[test]
+    fn assess_risk_combined_sanctions_and_oracle() {
+        let env = setup_env();
+        let admin = bootstrap(&env);
+        let oracle = Address::generate(&env);
+        let source = create_list(&env, &admin, b"OFAC");
+        let target = Address::generate(&env);
+
+        // Sanction the address
+        ComplianceFilter::add_to_sanctions_list(
+            env.clone(),
+            admin.clone(),
+            source,
+            target.clone(),
+            Bytes::from_slice(&env, b"fraud"),
+            Bytes::from_slice(&env, b"US"),
+        )
+        .unwrap();
+
+        // Also assign a high oracle score
+        ComplianceFilter::register_oracle(env.clone(), admin, oracle.clone()).unwrap();
+        ComplianceFilter::update_risk_score(
+            env.clone(),
+            oracle,
+            target.clone(),
+            90,
+            Bytes::from_slice(&env, b"suspicious"),
+        )
+        .unwrap();
+
+        let assessment = ComplianceFilter::assess_risk(env.clone(), target);
+        // sanctions=100*50 + oracle=90*50 = 9500 / 100 = 95
+        assert_eq!(assessment.score, 95);
+        assert_eq!(assessment.overall, RiskLevel::High);
+    }
+
+    // ── set_risk_weights ──────────────────────────────────────────────────────
+
+    #[test]
+    fn set_risk_weights_stores_and_retrieves() {
+        let env = setup_env();
+        let admin = bootstrap(&env);
+
+        let weights = RiskWeights {
+            sanctions_weight: 70,
+            oracle_weight: 30,
+            high_risk_threshold: 75,
+            last_updated: 0,
+        };
+
+        ComplianceFilter::set_risk_weights(env.clone(), admin, weights).unwrap();
+
+        let stored = ComplianceFilter::get_risk_weights(env.clone()).unwrap();
+        assert_eq!(stored.sanctions_weight, 70);
+        assert_eq!(stored.oracle_weight, 30);
+        assert_eq!(stored.high_risk_threshold, 75);
+    }
+
+    #[test]
+    fn set_risk_weights_rejects_zero_threshold() {
+        let env = setup_env();
+        let admin = bootstrap(&env);
+
+        let weights = RiskWeights {
+            sanctions_weight: 50,
+            oracle_weight: 50,
+            high_risk_threshold: 0,
+            last_updated: 0,
+        };
+
+        let result = ComplianceFilter::set_risk_weights(env.clone(), admin, weights);
+        assert_eq!(result.unwrap_err(), ComplianceFilterError::InvalidRiskScore);
+    }
+
+    #[test]
+    fn set_risk_weights_rejects_threshold_above_max() {
+        let env = setup_env();
+        let admin = bootstrap(&env);
+
+        let weights = RiskWeights {
+            sanctions_weight: 50,
+            oracle_weight: 50,
+            high_risk_threshold: MAX_RISK_SCORE + 1,
+            last_updated: 0,
+        };
+
+        let result = ComplianceFilter::set_risk_weights(env.clone(), admin, weights);
+        assert_eq!(result.unwrap_err(), ComplianceFilterError::InvalidRiskScore);
+    }
+
+    #[test]
+    fn set_risk_weights_non_admin_rejected() {
+        let env = setup_env();
+        bootstrap(&env);
+        let intruder = Address::generate(&env);
+
+        let weights = RiskWeights {
+            sanctions_weight: 70,
+            oracle_weight: 30,
+            high_risk_threshold: 70,
+            last_updated: 0,
+        };
+
+        let result = ComplianceFilter::set_risk_weights(env.clone(), intruder, weights);
+        assert_eq!(result.unwrap_err(), ComplianceFilterError::Unauthorized);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ mod integration_tests;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, Symbol, Vec};
 
 pub use compliance_filter::ComplianceFilter;
+pub use compliance_filter::RiskAssessment;
+pub use compliance_filter::RiskFactor;
+pub use compliance_filter::RiskLevel;
 pub use credential_issuer::CredentialIssuer;
 pub use credential_offer::CredentialOffer;
 pub use credential_offer::CredentialOfferContract;


### PR DESCRIPTION
Fixes issues #21, #22, #23, #24. Adds RiskLevel/RiskFactor/RiskAssessment types with assess_risk and set_risk_weights to compliance_filter contract. Adds UpdateDIDOptions type and overload for DIDClient. Adds comprehensive unit tests for DIDClient (18 tests), CredentialClient (18 tests), and ReputationClient (25 tests) with mocked contract responses. All 61 new tests passing.
closes #21
closes #22
closes #23
closes #24