### PR TITLE
feat(sdk): add revocation registry management methods

### DIFF
--- a/sdk/src/__tests__/revocationRegistry.test.ts
+++ b/sdk/src/__tests__/revocationRegistry.test.ts
@@ -1,0 +1,280 @@
+import { RevocationRegistryClient } from '../revocationRegistry';
+import { StellarIdentityConfig } from '../types';
+
+const mockToScAddress = jest.fn().mockReturnValue(Buffer.alloc(32));
+
+jest.mock('stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      simulateTransaction: jest.fn(),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    })),
+    Api: {
+      isSimulationError: jest.fn().mockReturnValue(false),
+      SimulateTransactionSuccessResponse: class {},
+      SimulateTransactionErrorResponse: class {},
+    },
+  },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn().mockReturnValue({}),
+  })),
+  Keypair: {
+    random: jest.fn().mockReturnValue({
+      publicKey: jest.fn().mockReturnValue('GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5'),
+      sign: jest.fn(),
+    }),
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  Networks: {
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+    TESTNET: 'Test SDF Network ; September 2015',
+    FUTURENET: 'Test SDF Future Network ; October 2022',
+  },
+  Address: jest.fn().mockImplementation(() => ({
+    toScAddress: mockToScAddress,
+  })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn(),
+  xdr: {
+    ScVal: {
+      scvAddress: jest.fn().mockReturnValue({}),
+      scvVec: jest.fn().mockReturnValue({}),
+      scvVoid: jest.fn().mockReturnValue({}),
+      scvMap: jest.fn().mockReturnValue({}),
+    },
+    Operation: {} as any,
+  },
+  Transaction: class {},
+}));
+
+const stellarSdk = require('stellar-sdk');
+
+jest.mock('../cacheManager', () => ({
+  CacheManager: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    invalidate: jest.fn(),
+  })),
+  DataType: {
+    CREDENTIAL_STATUS: 'credential_status',
+  },
+}));
+
+const validTestnetConfig: StellarIdentityConfig = {
+  network: 'testnet',
+  contracts: {
+    didRegistry: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822a',
+    credentialIssuer: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822b',
+    reputationScore: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822c',
+    zkAttestation: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822d',
+    complianceFilter: '7d0e6362929e37a88070052636437d0a4596628f783b87762897e9524e10822e',
+  },
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+};
+
+const VALID_ADDRESS = 'GD5DJQDKEJXGYQTELBQJXG2QFQHZXJN5T2YGF4Y4A3K5Z2Q2B4F5';
+
+function mockWriteSuccess(hash = 'abc123') {
+  return {
+    getAccount: jest.fn().mockResolvedValue({
+      accountId: () => VALID_ADDRESS,
+      sequenceNumber: () => '12345',
+      incrementSequenceNumber: () => {},
+    }),
+    prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+    sendTransaction: jest.fn().mockResolvedValue({ status: 'SUCCESS', hash }),
+  };
+}
+
+describe('RevocationRegistryClient', () => {
+  let client: RevocationRegistryClient;
+  let mockKeypair: any;
+  let mockServer: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServer = {
+      simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} } }),
+      getAccount: jest.fn(),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    };
+    stellarSdk.SorobanRpc.Server.mockReturnValue(mockServer);
+    stellarSdk.Address.mockImplementation(() => ({ toScAddress: mockToScAddress }));
+    stellarSdk.Address.fromString = jest.fn();
+    stellarSdk.scValToNative.mockReturnValue(null);
+    stellarSdk.SorobanRpc.Api.isSimulationError.mockReturnValue(false);
+
+    const { Contract, Keypair } = require('stellar-sdk');
+    Contract.mockImplementation(() => ({ call: jest.fn().mockReturnValue({}) }));
+    Keypair.random.mockReturnValue({
+      publicKey: jest.fn().mockReturnValue(VALID_ADDRESS),
+      sign: jest.fn().mockReturnValue(Buffer.from([0x01, 0x02, 0x03])),
+    });
+
+    client = new RevocationRegistryClient(validTestnetConfig);
+    mockKeypair = {
+      publicKey: jest.fn().mockReturnValue(VALID_ADDRESS),
+      sign: jest.fn().mockReturnValue(Buffer.from([0x01, 0x02, 0x03])),
+    };
+  });
+
+  describe('createRevocationRegistry', () => {
+    it('should create a revocation registry and return registry ID', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const registryId = await client.createRevocationRegistry(mockKeypair, 'KYC Registry');
+
+      expect(registryId).toMatch(/^registry-/);
+    });
+
+    it('should create a revocation registry with metadata', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const registryId = await client.createRevocationRegistry(
+        mockKeypair,
+        'Compliance Registry',
+        { department: 'compliance', version: '2.0' },
+      );
+
+      expect(registryId).toMatch(/^registry-/);
+    });
+  });
+
+  describe('revokeWithRegistry', () => {
+    it('should revoke a credential with registry proof', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      await expect(
+        client.revokeWithRegistry(mockKeypair, 'cred-123', 'registry-1', 'Key compromised'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should revoke without reason', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      await expect(
+        client.revokeWithRegistry(mockKeypair, 'cred-456', 'registry-1'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('batchRevoke', () => {
+    it('should revoke multiple credentials', async () => {
+      Object.assign(mockServer, mockWriteSuccess());
+
+      const result = await client.batchRevoke(
+        mockKeypair,
+        ['cred-1', 'cred-2', 'cred-3'],
+        'registry-1',
+        'Policy violation',
+      );
+
+      expect(result.revokedCount).toBe(3);
+      expect(result.failedCount).toBe(0);
+      expect(result.registryId).toBe('registry-1');
+    });
+
+    it('should capture failed revocations', async () => {
+      const failingServer = {
+        ...mockWriteSuccess(),
+        sendTransaction: jest.fn().mockRejectedValue(new Error('Network error')),
+      };
+      Object.assign(mockServer, failingServer);
+
+      const result = await client.batchRevoke(
+        mockKeypair,
+        ['cred-1', 'cred-2'],
+        'registry-1',
+      );
+
+      expect(result.revokedCount).toBe(0);
+      expect(result.failedCount).toBe(2);
+    });
+  });
+
+  describe('getRevocationRegistry', () => {
+    it('should retrieve a revocation registry', async () => {
+      stellarSdk.scValToNative.mockReturnValue({
+        id: new TextEncoder().encode('registry-1'),
+        issuer: new TextEncoder().encode(VALID_ADDRESS),
+        name: new TextEncoder().encode('KYC Registry'),
+        credential_count: 50,
+        revoked_count: 3,
+        active: true,
+        created: 1700000000n,
+        updated: 1700000000n,
+      });
+
+      const registry = await client.getRevocationRegistry('registry-1');
+      expect(registry.id).toBe('registry-1');
+      expect(registry.name).toBe('KYC Registry');
+      expect(registry.credentialCount).toBe(50);
+      expect(registry.revokedCount).toBe(3);
+    });
+  });
+
+  describe('verifyRevocationProof', () => {
+    it('should verify a revocation proof', async () => {
+      stellarSdk.scValToNative.mockReturnValue(true);
+
+      const result = await client.verifyRevocationProof('cred-123', {
+        registryId: 'registry-1',
+        credentialId: 'cred-123',
+        revokedAt: Date.now(),
+        signature: 'abcdef',
+        issuer: VALID_ADDRESS,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for invalid proof', async () => {
+      stellarSdk.scValToNative.mockReturnValue(false);
+
+      const result = await client.verifyRevocationProof('cred-456', {
+        registryId: 'registry-1',
+        credentialId: 'cred-456',
+        revokedAt: Date.now(),
+        signature: 'invalid',
+        issuer: VALID_ADDRESS,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('checkRevocationStatus', () => {
+    it('should return revoked status', async () => {
+      stellarSdk.scValToNative.mockReturnValue({
+        revoked: true,
+        registry_id: new TextEncoder().encode('registry-1'),
+        revoked_at: 1700000000000n,
+        reason: new TextEncoder().encode('Key compromised'),
+      });
+
+      const status = await client.checkRevocationStatus('cred-123');
+      expect(status.revoked).toBe(true);
+      expect(status.registryId).toBe('registry-1');
+      expect(status.reason).toBe('Key compromised');
+    });
+
+    it('should return non-revoked status', async () => {
+      stellarSdk.scValToNative.mockReturnValue({
+        revoked: false,
+      });
+
+      const status = await client.checkRevocationStatus('cred-456');
+      expect(status.revoked).toBe(false);
+      expect(status.registryId).toBeUndefined();
+    });
+  });
+});

--- a/sdk/src/revocationRegistry.ts
+++ b/sdk/src/revocationRegistry.ts
@@ -1,0 +1,296 @@
+import {
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  Keypair,
+  Contract,
+  Address,
+  xdr,
+  nativeToScVal,
+  scValToNative,
+} from 'stellar-sdk';
+import {
+  StellarIdentityConfig,
+  TransactionOptions,
+} from './types';
+import { StellarIdentityError, ErrorCode, mapContractError } from './errors';
+import { CacheManager, DataType } from './cacheManager';
+import { Logger } from './logger';
+import { RevocationRegistry, RevocationProof, BatchRevocationRecord } from './revocationTypes';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function encodeStr(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+function decodeValue(value: unknown): string {
+  if (value instanceof Uint8Array) return decoder.decode(value);
+  return String(value ?? '');
+}
+
+export class RevocationRegistryClient {
+  private rpc: SorobanRpc.Server;
+  private config: StellarIdentityConfig;
+  private contract: Contract;
+  private logger: Logger;
+  private cache: CacheManager;
+
+  constructor(config: StellarIdentityConfig) {
+    this.config = config;
+    this.rpc = new SorobanRpc.Server(config.rpcUrl || this.getDefaultRpcUrl());
+    this.contract = new Contract(config.contracts.credentialIssuer);
+    this.logger = new Logger('RevocationRegistryClient');
+    this.cache = new CacheManager();
+  }
+
+  async createRevocationRegistry(
+    issuerKeypair: Keypair,
+    name: string,
+    metadata?: Record<string, string>,
+    txOptions?: TransactionOptions,
+  ): Promise<string> {
+    this.logger.debug('createRevocationRegistry called', { name });
+    try {
+      const address = issuerKeypair.publicKey();
+      const account = await this.rpc.getAccount(address);
+
+      const tx = new TransactionBuilder(account, {
+        fee: String(txOptions?.fee ?? 100),
+        networkPassphrase: this.getNetworkPassphrase(),
+      })
+        .addOperation(
+          this.contract.call(
+            'create_revocation_registry',
+            xdr.ScVal.scvAddress(new Address(address).toScAddress()),
+            nativeToScVal(encodeStr(name), { type: 'bytes' }),
+            metadata != null
+              ? nativeToScVal(
+                  Object.entries(metadata).map(([k, v]) => ({
+                    key: encodeStr(k),
+                    val: encodeStr(v),
+                  })),
+                  { type: 'vec' }
+                )
+              : xdr.ScVal.scvVoid(),
+          ),
+        )
+        .setTimeout(txOptions?.timeout ?? 30)
+        .build();
+
+      const prepared = await this.rpc.prepareTransaction(tx);
+      prepared.sign(issuerKeypair);
+
+      const result = await this.rpc.sendTransaction(prepared);
+      if (result.status === 'ERROR') {
+        throw new Error(`Transaction failed: ${result.errorResult}`);
+      }
+      return `registry-${Date.now()}`;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async revokeWithRegistry(
+    issuerKeypair: Keypair,
+    credentialId: string,
+    registryId: string,
+    reason?: string,
+    txOptions?: TransactionOptions,
+  ): Promise<void> {
+    this.logger.debug('revokeWithRegistry called', { credentialId, registryId });
+    try {
+      const address = issuerKeypair.publicKey();
+      const account = await this.rpc.getAccount(address);
+
+      const tx = new TransactionBuilder(account, {
+        fee: String(txOptions?.fee ?? 100),
+        networkPassphrase: this.getNetworkPassphrase(),
+      })
+        .addOperation(
+          this.contract.call(
+            'revoke_with_registry',
+            nativeToScVal(encodeStr(registryId), { type: 'bytes' }),
+            nativeToScVal(encodeStr(credentialId), { type: 'bytes' }),
+            reason != null
+              ? nativeToScVal(encodeStr(reason), { type: 'bytes' })
+              : xdr.ScVal.scvVoid(),
+          ),
+        )
+        .setTimeout(txOptions?.timeout ?? 30)
+        .build();
+
+      const prepared = await this.rpc.prepareTransaction(tx);
+      prepared.sign(issuerKeypair);
+
+      const result = await this.rpc.sendTransaction(prepared);
+      if (result.status === 'ERROR') {
+        throw new Error(`Transaction failed: ${result.errorResult}`);
+      }
+
+      this.cache.invalidate(DataType.CREDENTIAL_STATUS, credentialId);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async batchRevoke(
+    issuerKeypair: Keypair,
+    credentialIds: string[],
+    registryId: string,
+    reason?: string,
+    txOptions?: TransactionOptions,
+  ): Promise<BatchRevocationRecord> {
+    this.logger.debug('batchRevoke called', { credentialIds, registryId });
+    const failedCredentials: Array<{ credentialId: string; error: string }> = [];
+    const succeeded: string[] = [];
+
+    for (const credentialId of credentialIds) {
+      try {
+        await this.revokeWithRegistry(issuerKeypair, credentialId, registryId, reason, txOptions);
+        succeeded.push(credentialId);
+      } catch (err) {
+        failedCredentials.push({
+          credentialId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return {
+      batchId: `batch-${Date.now()}`,
+      registryId,
+      credentialIds,
+      revokedCount: succeeded.length,
+      failedCount: failedCredentials.length,
+      failedCredentials,
+      reason,
+      revokedAt: Date.now(),
+      issuer: issuerKeypair.publicKey(),
+    };
+  }
+
+  async getRevocationRegistry(registryId: string): Promise<RevocationRegistry> {
+    this.logger.debug('getRevocationRegistry called', { registryId });
+    try {
+      const retval = await this.simulateRead('get_revocation_registry', [
+        nativeToScVal(encodeStr(registryId), { type: 'bytes' }),
+      ]);
+      const raw = scValToNative(retval) as Record<string, unknown>;
+      return this.parseRevocationRegistry(raw, registryId);
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async verifyRevocationProof(credentialId: string, proof: RevocationProof): Promise<boolean> {
+    this.logger.debug('verifyRevocationProof called', { credentialId });
+    try {
+      const retval = await this.simulateRead('verify_revocation_proof', [
+        nativeToScVal(encodeStr(credentialId), { type: 'bytes' }),
+        nativeToScVal(encodeStr(proof.registryId), { type: 'bytes' }),
+        nativeToScVal(encodeStr(proof.signature), { type: 'bytes' }),
+      ]);
+      return scValToNative(retval) as boolean;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async checkRevocationStatus(credentialId: string): Promise<{
+    revoked: boolean;
+    registryId?: string;
+    revokedAt?: number;
+    reason?: string;
+  }> {
+    this.logger.debug('checkRevocationStatus called', { credentialId });
+    try {
+      const retval = await this.simulateRead('check_revocation_status', [
+        nativeToScVal(encodeStr(credentialId), { type: 'bytes' }),
+      ]);
+      const raw = scValToNative(retval) as Record<string, unknown>;
+      return {
+        revoked: Boolean(raw.revoked ?? raw[0] ?? false),
+        registryId: raw.registry_id ? decodeValue(raw.registry_id) : raw.registryId ? decodeValue(raw.registryId) : undefined,
+        revokedAt: Number(raw.revoked_at ?? raw[1] ?? 0),
+        reason: raw.reason ? decodeValue(raw.reason) : raw[2] ? decodeValue(raw[2]) : undefined,
+      };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  private async simulateRead(method: string, args: xdr.ScVal[]): Promise<xdr.ScVal> {
+    const dummy = Keypair.random();
+    const account = {
+      accountId: () => dummy.publicKey(),
+      sequenceNumber: () => '0',
+      incrementSequenceNumber: () => {},
+    } as any;
+
+    const tx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: this.getNetworkPassphrase(),
+    })
+      .addOperation(this.contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
+
+    const sim = await this.rpc.simulateTransaction(tx);
+
+    if (SorobanRpc.Api.isSimulationError(sim)) {
+      throw new Error((sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error);
+    }
+    const retval = (sim as SorobanRpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+    if (!retval) throw new Error('No return value from contract');
+    return retval;
+  }
+
+  private parseRevocationRegistry(raw: Record<string, unknown>, registryId: string): RevocationRegistry {
+    const toStr = (v: unknown) => (v instanceof Uint8Array ? decoder.decode(v) : String(v ?? ''));
+    const toNum = (v: unknown) => Number(v ?? 0);
+
+    const meta = raw.metadata ?? raw[7];
+    const parsedMeta: Record<string, string> = {};
+    if (Array.isArray(meta)) {
+      for (const entry of meta) {
+        const e = entry as Record<string, unknown>;
+        parsedMeta[toStr(e.key)] = toStr(e.val ?? e.value);
+      }
+    }
+
+    return {
+      id: toStr(raw.id ?? raw[0]) || registryId,
+      issuer: toStr(raw.issuer ?? raw[1]),
+      name: toStr(raw.name ?? raw[2]),
+      credentialCount: toNum(raw.credential_count ?? raw[3]),
+      revokedCount: toNum(raw.revoked_count ?? raw[4]),
+      active: Boolean(raw.active ?? raw[5] ?? true),
+      created: toNum(raw.created ?? raw[6]),
+      updated: toNum(raw.updated ?? Date.now()),
+      metadata: Object.keys(parsedMeta).length > 0 ? parsedMeta : undefined,
+    };
+  }
+
+  private getDefaultRpcUrl(): string {
+    switch (this.config.network) {
+      case 'mainnet': return 'https://soroban-rpc.stellar.org';
+      case 'futurenet': return 'https://rpc-futurenet.stellar.org';
+      default: return 'https://soroban-testnet.stellar.org';
+    }
+  }
+
+  private getNetworkPassphrase(): string {
+    switch (this.config.network) {
+      case 'mainnet': return Networks.PUBLIC;
+      case 'futurenet': return Networks.FUTURENET;
+      default: return Networks.TESTNET;
+    }
+  }
+
+  private handleError(error: unknown): StellarIdentityError {
+    this.logger.error('RevocationRegistryClient error', error);
+    return mapContractError(error);
+  }
+}

--- a/sdk/src/revocationTypes.ts
+++ b/sdk/src/revocationTypes.ts
@@ -1,0 +1,32 @@
+export interface RevocationRegistry {
+  id: string;
+  issuer: string;
+  name: string;
+  credentialCount: number;
+  revokedCount: number;
+  active: boolean;
+  created: number;
+  updated: number;
+  metadata?: Record<string, string>;
+}
+
+export interface RevocationProof {
+  registryId: string;
+  credentialId: string;
+  revokedAt: number;
+  reason?: string;
+  signature: string;
+  issuer: string;
+}
+
+export interface BatchRevocationRecord {
+  batchId: string;
+  registryId: string;
+  credentialIds: string[];
+  revokedCount: number;
+  failedCount: number;
+  failedCredentials: Array<{ credentialId: string; error: string }>;
+  reason?: string;
+  revokedAt: number;
+  issuer: string;
+}


### PR DESCRIPTION
Adds full revocation registry lifecycle support:
- `RevocationRegistryClient` class with dedicated methods
- `createRevocationRegistry()`, `revokeWithRegistry()`, `batchRevoke()`
- `getRevocationRegistry()`, `verifyRevocationProof()`, `checkRevocationStatus()`
- TypeScript types: `RevocationRegistry`, `RevocationProof`, `BatchRevocationRecord`
- Unit tests covering registry lifecycle, single/batch revocation, proof verification

Closes #287