### PR TITLE
feat: implement typed proof submission with public input validation (#288)

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -336,6 +336,36 @@ export interface ZKProofOptions {
   txOptions?: TransactionOptions;
 }
 
+/**
+ * Options for typed proof submission (Issue #288).
+ * Configurable expiration, metadata, and revealed attributes.
+ */
+export interface ProofOptions {
+  /** Unix timestamp (seconds) when the proof expires. 0 = no expiration. */
+  expiration?: number;
+  /** Additional metadata to attach to the proof. */
+  metadata?: Record<string, string>;
+  /** Attributes to reveal publicly with the proof. */
+  revealedAttributes?: string[];
+  /** Transaction options (fee, timeout, etc.). */
+  txOptions?: TransactionOptions;
+}
+
+/**
+ * Public inputs for nationality proof (Issue #288).
+ */
+export interface NationalityProofInputs {
+  nationalityCommitment: string;
+  allowedCountries: string[];
+}
+
+/**
+ * Public inputs for credential ownership proof (Issue #288).
+ */
+export interface CredentialOwnershipProofInputs {
+  credentialId: string;
+}
+
 export interface ProofGenerationInputs {
   [key: string]: any;
 }
@@ -472,6 +502,36 @@ export interface SelectiveDisclosureOptions {
   metadata?: Record<string, string>;
   context?: string;
   txOptions?: TransactionOptions;
+}
+
+/**
+ * Options for typed proof submission (Issue #288).
+ * Configurable expiration, metadata, and revealed attributes.
+ */
+export interface ProofOptions {
+  /** Unix timestamp (seconds) when the proof expires. 0 = no expiration. */
+  expiration?: number;
+  /** Additional metadata to attach to the proof. */
+  metadata?: Record<string, string>;
+  /** Attributes to reveal publicly with the proof. */
+  revealedAttributes?: string[];
+  /** Transaction options (fee, timeout, etc.). */
+  txOptions?: TransactionOptions;
+}
+
+/**
+ * Public inputs for nationality proof (Issue #288).
+ */
+export interface NationalityProofInputs {
+  nationalityCommitment: string;
+  allowedCountries: string[];
+}
+
+/**
+ * Public inputs for credential ownership proof (Issue #288).
+ */
+export interface CredentialOwnershipProofInputs {
+  credentialId: string;
 }
 
 export interface SelectiveDisclosureProof {

--- a/sdk/src/zkProofs.ts
+++ b/sdk/src/zkProofs.ts
@@ -26,6 +26,8 @@ import {
   SelectiveDisclosureProof,
   SelectiveDisclosureVerificationResult,
   CombinedDisclosureProof,
+  ProofOptions,
+  NationalityProofInputs,
 } from './types';
 import { StellarIdentityError, mapContractError } from './errors';
 
@@ -1121,6 +1123,10 @@ export class ZKProofsClient {
     proofBytes: string,
     txOptions?: TransactionOptions
   ): Promise<string> {
+    // Issue #288: Validate public input types
+    if (!credentialHash || credentialHash.length === 0) {
+      throw new StellarIdentityError('credentialHash is required', 'INVALID_INPUT');
+    }
     return this.submitProof(
       submitterKeypair,
       {
@@ -1132,6 +1138,112 @@ export class ZKProofsClient {
         metadata: { type: 'credential_ownership' },
       },
       txOptions
+    );
+  }
+
+  /**
+   * Submit a nationality proof with typed public inputs (Issue #288).
+   * @param submitterKeypair - The keypair of the proof submitter
+   * @param circuitId - The circuit identifier
+   * @param nationalityCommitment - Commitment to the user's nationality
+   * @param allowedCountries - Array of allowed country codes
+   * @param proofBytes - The ZK proof bytes
+   * @param options - Optional ProofOptions (expiration, metadata, revealedAttributes)
+   * @returns The proof ID
+   */
+  async submitNationalityProof(
+    submitterKeypair: Keypair,
+    circuitId: string,
+    nationalityCommitment: string,
+    allowedCountries: string[],
+    proofBytes: string,
+    options?: ProofOptions
+  ): Promise<string> {
+    // Issue #288: Validate public input types
+    if (!nationalityCommitment || nationalityCommitment.length === 0) {
+      throw new StellarIdentityError('nationalityCommitment is required', 'INVALID_INPUT');
+    }
+    if (!Array.isArray(allowedCountries) || allowedCountries.length === 0) {
+      throw new StellarIdentityError('allowedCountries must be a non-empty array', 'INVALID_INPUT');
+    }
+    return this.submitProof(
+      submitterKeypair,
+      {
+        circuitId,
+        publicInputs: [nationalityCommitment, JSON.stringify(allowedCountries)],
+        proofBytes,
+        nullifier: this.generateNullifier(`nationality_${nationalityCommitment}`, circuitId, 'manual'),
+        revealedAttributes: options?.revealedAttributeAttribute ?? ['nationality_commitment'],
+        expiresAt: options?.expiration,
+        metadata: { type: 'nationality_verification', countries: allowedCountries.join(','), ...options?.metadata },
+      },
+      options?.txOptions
+    );
+  }
+
+  /**
+   * Submit an age proof with typed public inputs and ProofOptions (Issue #288).
+   */
+  async submitAgeProofTyped(
+    submitterKeypair: Keypair,
+    circuitId: string,
+    ageCommitment: string,
+    minAge: number,
+    proofBytes: string,
+    options?: ProofOptions
+  ): Promise<string> {
+    // Issue #288: Validate public input types
+    if (!ageCommitment || ageCommitment.length === 0) {
+      throw new StellarIdentityError('ageCommitment is required', 'INVALID_INPUT');
+    }
+    if (typeof minAge !== 'number' || minAge < 0 || minAge > 150) {
+      throw new StellarIdentityError('minAge must be a number between 0 and 150', 'INVALID_INPUT');
+    }
+    return this.submitProof(
+      submitterKeypair,
+      {
+        circuitId,
+        publicInputs: [ageCommitment, String(minAge)],
+        proofBytes,
+        nullifier: this.generateNullifier(`age_${minAge}`, circuitId, 'manual'),
+        revealedAttributes: options?.revealedAttributes ?? ['age_commitment'],
+        expiresAt: options?.expiration,
+        metadata: { type: 'age_verification', minAge: String(minAge), ...options?.metadata },
+      },
+      options?.txOptions
+    );
+  }
+
+  /**
+   * Submit an income proof with typed public inputs and ProofOptions (Issue #288).
+   */
+  async submitIncomeProofTyped(
+    submitterKeypair: Keypair,
+    circuitId: string,
+    incomeCommitment: string,
+    minIncome: number,
+    proofBytes: string,
+    options?: ProofOptions
+  ): Promise<string> {
+    // Issue #288: Validate public input types
+    if (!incomeCommitment || incomeCommitment.length === 0) {
+      throw new StellarIdentityError('incomeCommitment is required', 'INVALID_INPUT');
+    }
+    if (typeof minIncome !== 'number' || minIncome < 0) {
+      throw new StellarIdentityError('minIncome must be a non-negative number', 'INVALID_INPUT');
+    }
+    return this.submitProof(
+      submitterKeypair,
+      {
+        circuitId,
+        publicInputs: [incomeCommitment, String(minIncome)],
+        proofBytes,
+        nullifier: this.generateNullifier(`income_${minIncome}`, circuitId, 'manual'),
+        revealedAttributes: options?.revealedAttributes ?? ['income_commitment'],
+        expiresAt: options?.expiration,
+        metadata: { type: 'income_verification', minIncome: String(minIncome), ...options?.metadata },
+      },
+      options?.txOptions
     );
   }
 


### PR DESCRIPTION
## Summary

Implements **Issue #288**: Implement proof submission with typed public inputs in SDK.

### New Types
- `ProofOptions` interface: configurable expiration, metadata, revealedAttributes, txOptions
- `NationalityProofInputs`: nationalityCommitment + allowedCountries array
- `CredentialOwnershipProofInputs`: credentialId

### New Methods
- `submitNationalityProof()`: nationality proof with commitment + allowed countries
- `submitAgeProofTyped()`: age proof with ageCommitment, minAge (0-150 validation)
- `submitIncomeProofTyped()`: income proof with incomeCommitment, minIncome (non-negative validation)

### Input Validation
- All typed methods validate public input types before submission
- `submitCredentialOwnershipProof()` now validates credentialHash is non-empty
- Age proof validates minAge is 0-150
- Income proof validates minIncome is non-negative
- Nationality proof validates allowedCountries is a non-empty array

### Acceptance Criteria
- [x] `submitAgeProof` typed method with validation
- [x] `submitIncomeProof` typed method with validation
- [x] `submitNationalityProof` typed method
- [x] `submitCredentialOwnershipProof` with validation
- [x] Each method validates public input types before submission
- [x] `ProofOptions` interface with configurable expiration, metadata, revealed attributes

Closes #288